### PR TITLE
Add CLI option for local HTML_CodeSniffer

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -24,6 +24,11 @@ program
 		'WCAG2AA'
 	)
 	.option(
+		'-c, --htmlcs <url>',
+		'specify a URL to source HTML_CodeSniffer from. Default: squizlabs.github.io',
+		'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js'
+	)
+	.option(
 		'-t, --timeout <ms>',
 		'specify the number of milliseconds before a timeout error occurs. Default: 30000',
 		30000
@@ -65,6 +70,7 @@ loadReporter(program.reporter, function (err, reporter) {
 		url: url,
 		reporter: reporter,
 		standard: program.standard,
+		htmlcs: program.htmlcs,
 		timeout: timeout,
 		debug: program.debug
 	}, function (err) {

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -1,4 +1,4 @@
-/* globals document, window */
+/* globals window */
 'use strict';
 
 // Dependencies
@@ -14,6 +14,7 @@ exports.sniff = function (opts, callback) {
 		url: sanitizeUrl(opts.url),
 		standard: opts.standard,
 		reporter: opts.reporter,
+		htmlcs: opts.htmlcs,
 		timeout: opts.timeout,
 		debug: opts.debug
 	};
@@ -103,11 +104,7 @@ function setupVars (self, next) {
 // Load the script
 function loadScript (self, next) {
 	self.reporter.log('Loading HTML CodeSniffer...');
-	self.page.evaluate(function () {
-		var script = document.createElement('script');
-		script.src = 'http://squizlabs.github.com/HTML_CodeSniffer/build/HTMLCS.js';
-		document.head.appendChild(script);
-	}, function () {
+	self.page.includeJs(self.htmlcs, function () {
 		wait(self.page, function () {
 			return (typeof window.HTMLCS !== 'undefined');
 		}, function () {


### PR DESCRIPTION
Added an optional CLI option to specify a URL to soure the HTML_CodeSniffer JavaScript from. Fixes #10.

To use a local copy of HTML_CodeSniffer, clone the repository and start a HTTP server in the root directory. For example,

``` bash
git clone git://github.com/squizlabs/HTML_CodeSniffer.git
cd HTML_CodeSniffer
python -m SimpleHTTPServer # starts a server on port 8000
```

And run `pa11y -c 'http://localhost:8000/HTMLCS.js' foo.com`.
