### PR TITLE
Add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Once installed, the `pa11y` command should be available to you.
     -u, --useragent <ua>   specify a useragent to use when loading your URL. Default: pa11y/<version>
     -p, --port <port>      specify the port to run the PhantomJS server on. Default: 12300
     -d, --debug            output debug messages
+    --strict               upgrade warnings to errors for exit status
 
 ```
 

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -45,6 +45,10 @@ program
 		'-d, --debug',
 		'output debug messages'
 	)
+	.option(
+		'--strict',
+		'upgrade warnings to errors for exit status'
+	)
 	.usage('[options] <url>')
 	.parse(process.argv);
 
@@ -56,6 +60,7 @@ var opts = _.pick(program, [
 	'port',
 	'reporter',
 	'standard',
+	'strict',
 	'timeout',
 	'useragent'
 ]);
@@ -77,5 +82,8 @@ pa11y.sniff(opts, function (err, results) {
 	if (err instanceof OptionError) {
 		program.help();
 	}
-	process.exit(err ? 1 : results.count.error);
+	var exitStatus = err ? -1 :
+	opts.strict ? (results.count.warning + results.count.error) :
+	results.count.error;
+	process.exit(exitStatus);
 });

--- a/lib/sniff/manage-options.js
+++ b/lib/sniff/manage-options.js
@@ -53,6 +53,7 @@ exports.defaultOptions = {
 	htmlcs: 'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js',
 	port: 12300,
 	standard: 'WCAG2AA',
+	strict: false,
 	timeout: 30000,
 	useragent: 'pa11y/' + pkg.version
 };

--- a/test/unit/sniff/manage-options.js
+++ b/test/unit/sniff/manage-options.js
@@ -36,6 +36,7 @@ describe('sniff/manage-options', function () {
 			port: 12300,
 			reporter: 'bar',
 			standard: 'baz',
+			strict: false,
 			timeout: 123,
 			useragent: 'qux'
 		};
@@ -57,6 +58,7 @@ describe('sniff/manage-options', function () {
 				port: 12300,
 				reporter: 'foo',
 				standard: 'WCAG2AA',
+				strict: false,
 				timeout: 123,
 				useragent: 'pa11y/' + pkg.version
 			});


### PR DESCRIPTION
Related to #14.

A strict mode would upgrade warnings to errors when determining the exit status for the program. I imagine it would look something like `pa11y --strict foo.com`.

Thoughts on this?
