### PR TITLE
Return negative number for OptionError

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -81,7 +81,7 @@ if (!opts.config) {
 pa11y.sniff(opts, function (err, results) {
 	if (err instanceof OptionError) {
 		program.outputHelp();
-		process.exit(1);
+		process.exit(-1);
 	}
 	var exitStatus = err ? -1 :
 	opts.strict ? (results.count.warning + results.count.error) :


### PR DESCRIPTION
Positive non-zero numbers indicate the amount of errors in the page. A program error (or `OptionError`) should be negative.
