### PR TITLE
Remove redundant exit

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -81,7 +81,6 @@ if (!opts.config) {
 pa11y.sniff(opts, function (err, results) {
 	if (err instanceof OptionError) {
 		program.outputHelp();
-		process.exit(-1);
 	}
 	var exitStatus = err ? -1 :
 	opts.strict ? (results.count.warning + results.count.error) :


### PR DESCRIPTION
If there is an error it will still return with the same status.
