### PR TITLE
Add support for specifying a custom viewport size

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -133,6 +133,7 @@ exports.sniff = function (opts, callback) {
 			loadUrl(opts.url, {
 				userAgent: opts.useragent,
 				port: opts.port,
+				viewport: opts.viewport,
 				cookies: self.config.cookies,
 			}, function (err, browser, page) {
 				self.browser = browser;

--- a/lib/sniff/load-config.js
+++ b/lib/sniff/load-config.js
@@ -1,15 +1,15 @@
 // This file is part of pa11y.
-// 
+//
 // pa11y is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // pa11y is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/lib/sniff/load-url.js
+++ b/lib/sniff/load-url.js
@@ -36,6 +36,9 @@ exports = module.exports = function (url, options, callback) {
 			});
 			res.browser.createPage(function (page) {
 				page.set('settings.userAgent', options.userAgent);
+				if (options.viewport) {
+					page.set('viewportSize', options.viewport);
+				}
 				res.page = page;
 				next(null);
 			});

--- a/lib/sniff/manage-options.js
+++ b/lib/sniff/manage-options.js
@@ -1,15 +1,15 @@
 // This file is part of pa11y.
-// 
+//
 // pa11y is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // pa11y is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -33,6 +33,14 @@ exports = module.exports = function (opts, callback) {
 			opts.standard,
 			exports.allowableStandards,
 			'Standard must be one of ' + exports.allowableStandards.join(', ')
+		);
+		opts.viewport.height = manageNumericOption(
+			opts.viewport.height,
+			'Viewport height must be a number'
+		);
+		opts.viewport.width = manageNumericOption(
+			opts.viewport.width,
+			'Viewport width must be a number'
 		);
 	} catch (error) {
 		err = error;
@@ -70,6 +78,10 @@ exports.defaultOptions = {
 	standard: 'WCAG2AA',
 	strict: false,
 	timeout: 30000,
+	viewport: {
+		width: 640,
+		height: 480,
+	},
 	useragent: 'pa11y/' + pkg.version
 };
 

--- a/test/unit/pa11y.js
+++ b/test/unit/pa11y.js
@@ -50,7 +50,11 @@ describe('pa11y', function () {
 				reporter: 'bar',
 				config: 'baz',
 				port: 1234,
-				useragent: 'qux'
+				useragent: 'qux',
+				viewport: {
+					width: 1024,
+					height: 960,
+				},
 			};
 			manageOptions = sinon.stub().callsArgWith(1, null, opts);
 			mockery.registerMock('./sniff/manage-options', manageOptions);
@@ -170,6 +174,10 @@ describe('pa11y', function () {
 				assert.deepEqual({
 					userAgent: 'qux',
 					port: 1234,
+					viewport: {
+						width: 1024,
+						height: 960,
+					},
 					cookies: [
 						{
 							name: 'Valid-Cookie-Name',

--- a/test/unit/sniff/load-url.js
+++ b/test/unit/sniff/load-url.js
@@ -42,6 +42,10 @@ describe('sniff/load-url', function () {
 			userAgent: 'ua',
 			port: 1234,
 			cookies: [],
+			viewport: {
+				height: 1000,
+				width: 2000,
+			}
 		};
 	});
 
@@ -88,6 +92,17 @@ describe('sniff/load-url', function () {
 	it('should set the user agent string', function (done) {
 		loadUrl('successfulpage', options, function () {
 			assert.isTrue(page.set.withArgs('settings.userAgent', 'ua').calledOnce);
+			done();
+		});
+	});
+
+
+	it('should set the viewport size', function (done) {
+		loadUrl('successfulpage', options, function () {
+			assert.isTrue(page.set.withArgs('viewportSize', {
+				height: 1000,
+				width: 2000,
+			}).calledOnce);
 			done();
 		});
 	});

--- a/test/unit/sniff/manage-options.js
+++ b/test/unit/sniff/manage-options.js
@@ -1,15 +1,15 @@
 // This file is part of pa11y.
-// 
+//
 // pa11y is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // pa11y is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -53,6 +53,10 @@ describe('sniff/manage-options', function () {
 			standard: 'baz',
 			strict: false,
 			timeout: 123,
+			viewport: {
+				width: 10,
+				height: 20,
+			},
 			useragent: 'qux'
 		};
 		manageOptions(allOpts, function (err, opts) {
@@ -75,6 +79,10 @@ describe('sniff/manage-options', function () {
 				standard: 'WCAG2AA',
 				strict: false,
 				timeout: 123,
+				viewport: {
+					width: 640,
+					height: 480,
+				},
 				useragent: 'pa11y/' + pkg.version
 			});
 			done();


### PR DESCRIPTION
- change `sniff/loadUrl` argument signature to take an options object
- add `viewport` option for setting the viewport size

See #50.
