### PR TITLE
Allow setting phantomjs command line switches

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -58,6 +58,11 @@ program
 		'specify the size of the browser viewport. Default: 640x480'
 	)
 	.option(
+		'-p, --phantomOpts <string>',
+		'specify the phantomjs command line switches without leading dashes. Default: "".' +
+		'Example: "ssl-protocol=any load-images=false". '
+	)
+	.option(
 		'-p, --port <port>',
 		'specify the port to run the PhantomJS server on. Default: 12300'
 	)
@@ -82,7 +87,8 @@ var opts = _.pick(program, [
 	'standard',
 	'strict',
 	'timeout',
-	'useragent'
+	'useragent',
+	'phantomOpts'
 ]);
 opts.url = program.args[0];
 if (!opts.url || program.args[1]) {
@@ -106,6 +112,17 @@ if (program.viewport) {
 		width: viewport[0],
 		height: viewport[1]
 	};
+}
+
+if (program.phantomOpts) {
+	var phantomOpts = program.phantomOpts.split(' ').map(function (arg) {
+		/**
+		* Args must start with '--', but the node commander used
+		* doesn't accept arguments that start with '--'
+		**/
+		return '--' + arg;
+	});
+	opts.phantomOpts = phantomOpts;
 }
 
 // Run pa11y

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -131,6 +131,7 @@ exports.sniff = function (opts, callback) {
 			var cookies = self.config.cookies;
 			self.reporter.log('Loading page...');
 			loadUrl(opts.url, {
+				phantomOpts: opts.phantomOpts,
 				userAgent: opts.useragent,
 				port: opts.port,
 				viewport: opts.viewport,

--- a/lib/sniff/load-url.js
+++ b/lib/sniff/load-url.js
@@ -25,10 +25,14 @@ exports = module.exports = function (url, options, callback) {
 	var res = {};
 	async.series([
 		function (next) {
-			phantom.create({port: options.port}, function (browser) {
+			//There will be a variable number of args here, due to phantom command line switches
+			var args = options.phantomOpts || [];
+			args.push({port: options.port});
+			args.push(function (browser) {
 				res.browser = browser;
 				next(null);
 			});
+			phantom.create.apply(null, args);
 		},
 		function (next) {
 			_.each(options.cookies, function (cookie) {

--- a/lib/sniff/manage-options.js
+++ b/lib/sniff/manage-options.js
@@ -80,8 +80,9 @@ exports.defaultOptions = {
 	timeout: 30000,
 	viewport: {
 		width: 640,
-		height: 480,
+		height: 480
 	},
+	phantomOpts: [],
 	useragent: 'pa11y/' + pkg.version
 };
 

--- a/test/unit/pa11y.js
+++ b/test/unit/pa11y.js
@@ -53,8 +53,9 @@ describe('pa11y', function () {
 				useragent: 'qux',
 				viewport: {
 					width: 1024,
-					height: 960,
+					height: 960
 				},
+				phantomOpts: ['--ssl-protocol=any', '--load-images=false']
 			};
 			manageOptions = sinon.stub().callsArgWith(1, null, opts);
 			mockery.registerMock('./sniff/manage-options', manageOptions);
@@ -75,7 +76,7 @@ describe('pa11y', function () {
 				cookies: [{
 					'name': 'Valid-Cookie-Name',
 					'value': 'Valid-Cookie-Value',
-					'domain': 'localhost',
+					'domain': 'localhost'
 				}],
 				ignore: ['bar']
 			};
@@ -176,15 +177,16 @@ describe('pa11y', function () {
 					port: 1234,
 					viewport: {
 						width: 1024,
-						height: 960,
+						height: 960
 					},
+					phantomOpts: ['--ssl-protocol=any', '--load-images=false'],
 					cookies: [
 						{
 							name: 'Valid-Cookie-Name',
 							value: 'Valid-Cookie-Value',
-							domain: 'localhost',
+							domain: 'localhost'
 						},
-					],
+					]
 				}, args[1]);
 				// callback
 				assert.isFunction(args[2]);

--- a/test/unit/sniff/manage-options.js
+++ b/test/unit/sniff/manage-options.js
@@ -55,8 +55,9 @@ describe('sniff/manage-options', function () {
 			timeout: 123,
 			viewport: {
 				width: 10,
-				height: 20,
+				height: 20
 			},
+			phantomOpts: [],
 			useragent: 'qux'
 		};
 		manageOptions(allOpts, function (err, opts) {
@@ -81,8 +82,9 @@ describe('sniff/manage-options', function () {
 				timeout: 123,
 				viewport: {
 					width: 640,
-					height: 480,
+					height: 480
 				},
+				phantomOpts: [],
 				useragent: 'pa11y/' + pkg.version
 			});
 			done();


### PR DESCRIPTION
Fixes #53

This allows setting phantomjs command line switches via the pa11y config.
