### PR TITLE
Write a test to prove that hide elements is broken

### DIFF
--- a/test/integration/cli-hide-elements.js
+++ b/test/integration/cli-hide-elements.js
@@ -7,7 +7,7 @@ var describeCliCall = require('./helper/describe-cli-call');
 
 describe('Pa11y CLI Hide Elements', function() {
 
-	describeCliCall('/hide-elements', ['--hide-elements', '.heading'], {}, function() {
+	describeCliCall('/hide-elements', ['--hide-elements', '.heading,a'], {}, function() {
 
 		it('should respond with an exit code of `0`', function() {
 			assert.strictEqual(this.lastExitCode, 0);

--- a/test/integration/mock/html/hide-elements.html
+++ b/test/integration/mock/html/hide-elements.html
@@ -8,5 +8,6 @@
 </head>
 <body style="background:#fff">
 	<h1 style="color:#fff" class="heading">Hello World</h1>
+    <a href="http://www.nature.com/"></a>
 </body>
 </html>


### PR DESCRIPTION
See #146 for the original bug report. It looks like our current method for hiding these elements (adding `visibility:hidden`) only works for certain rules. We need to rethink the way this is implemented.