### PR TITLE
switch to https git clone, and make some corrections to make ops due …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ test-integration:
 # Rebuild a local HTML CodeSniffer
 build-htmlcs:
 	@echo "$(C_CYAN)> building HTML CodeSniffer$(C_RESET)"
-	@npm install git+ssh://git@github.com:squizlabs/HTML_CodeSniffer.git
+	@npm install git+https://git@github.com/squizlabs/HTML_CodeSniffer.git
 	@npm install -g grunt-cli
 	@cd ./node_modules/HTML_CodeSniffer && npm install --development
-	@cd ./node_modules/HTML_CodeSniffer/Contrib/Grunt && grunt build
+	@cd ./ grunt build
 	@cat ./lib/vendor/HTMLCS-LICENSE > lib/vendor/HTMLCS.js
-	@cat ./node_modules/HTML_CodeSniffer/build/HTMLCS.js >> lib/vendor/HTMLCS.js
+	@cat ./node_modules/HTML_CodeSniffer/HTMLCS.js >> lib/vendor/HTMLCS.jscs
 
 .PHONY: test


### PR DESCRIPTION
…to new HTMLCS structure

I've switched the git clone from ssh to https to correct the problem that Jose refers to in #144 - where npm has introduced a breaking change that stops ssh cloning from working properly. There's a lengthy thread about that here: https://github.com/npm/npm/issues/8031

After I did this, I realised that HTML codesniffer has some recent lib changes, so I've updated relevant locations for a couple of tasks. `make build-htmlcs` should now work correctly.  
