### PR TITLE
Fixes the hide-elements options

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -8,22 +8,8 @@ function injectPa11y(window, options, done) {
 		2: 'warning',
 		3: 'notice'
 	};
-	if (options.hideElements) {
-		hideElements();
-	}
 	setTimeout(runCodeSniffer, options.wait);
 
-	function hideElements() {
-		try {
-			var elementsToHide = window.document.querySelectorAll(options.hideElements);
-			for (var i = 0; i < elementsToHide.length; i++) {
-				elementsToHide[i].style.visibility = 'hidden';
-			}
-
-		} catch (error) {
-			reportError('Hiding elements: ' + error.message);
-		}
-	}
 
 	function runCodeSniffer() {
 		try {
@@ -42,6 +28,10 @@ function injectPa11y(window, options, done) {
 	function processMessages(messages) {
 		if (options.rootElement) {
 			messages = messages.filter(isMessageInTestArea);
+		}
+
+		if (options.hideElements) {
+			messages = messages.filter(isElementOutsideHiddenArea);
 		}
 
 		return messages.map(processMessage).filter(isMessageWanted);
@@ -128,6 +118,16 @@ function injectPa11y(window, options, done) {
 		}
 	}
 
+	function isElementOutsideHiddenArea(message) {
+		var hiddenSelectors = options.hideElements.split(',');
+		var element = message.element;
+		var elementsWithinHiddenSelectors = hiddenSelectors.filter(function(selector) {
+			return hiddenAreasContainsElement(element, selector);
+		});
+
+		return elementsWithinHiddenSelectors.length ? false : true;
+	}
+
 	function isElementWithinTestArea(child, parent) {
 		var node = child.parentNode;
 		while (node !== null) {
@@ -138,6 +138,26 @@ function injectPa11y(window, options, done) {
 		}
 
 		return false;
+	}
+
+	function hiddenAreasContainsElement(element, hiddenSelectors) {
+		/*jshint maxcomplexity:5, maxdepth:3 */
+		var hiddenElements = window.document.querySelectorAll(hiddenSelectors);
+
+		for (var i = 0; i < hiddenElements.length; i++) {
+			if (element.isEqualNode(hiddenElements[i])) {
+				return true;
+			}
+
+			var parent = element.parentNode;
+			while (parent) {
+				if (parent.isEqualNode(hiddenElements[i])) {
+					return true;
+				}
+				parent = parent.parentNode;
+			}
+		}
+
 	}
 
 	function isMessageWanted(message) {

--- a/test/integration/cli-hide-elements.js
+++ b/test/integration/cli-hide-elements.js
@@ -7,18 +7,30 @@ var describeCliCall = require('./helper/describe-cli-call');
 
 describe('Pa11y CLI Hide Elements', function() {
 
-	describeCliCall('/hide-elements', ['--hide-elements', '.heading'], {}, function() {
+	describeCliCall('/hide-elements', ['--hide-elements', '#hide-parent', '--ignore', 'warning;notice'], {}, function() {
 
 		it('should respond with an exit code of `0`', function() {
 			assert.strictEqual(this.lastExitCode, 0);
 		});
 
-		it('should respond with the expected messages', function() {
+		it('should respond with no errors', function() {
 			assert.isArray(this.lastJsonResponse);
-			assert.strictEqual(this.lastJsonResponse.length, 3);
-			assert.notStrictEqual(this.lastJsonResponse[0].type, 'error');
-			assert.notStrictEqual(this.lastJsonResponse[1].type, 'error');
-			assert.notStrictEqual(this.lastJsonResponse[2].type, 'error');
+			assert.strictEqual(this.lastJsonResponse.length, 0);
+		});
+
+	});
+
+	describeCliCall('/hide-elements', ['--hide-elements', 'h1,h2,img,iframe,#para,form,input', '--ignore', 'warning;notice'], {}, function() {
+
+		it('should respond with an exit code of `2`', function() {
+			assert.strictEqual(this.lastExitCode, 2);
+		});
+
+		it('should respond with the visible elements error messages', function() {
+			assert.isArray(this.lastJsonResponse);
+			assert.strictEqual(this.lastJsonResponse.length, 2);
+			assert.strictEqual(this.lastJsonResponse[0].context.match(/^(<h1|<h2|<img|<iframe|id="para|<form|<input")/), null);
+			assert.strictEqual(this.lastJsonResponse[1].context.match(/^(<h1|<h2|<img|<iframe|id="para|<form|<input")/), null);
 		});
 
 	});

--- a/test/integration/mock/html/hide-elements.html
+++ b/test/integration/mock/html/hide-elements.html
@@ -7,6 +7,37 @@
 
 </head>
 <body style="background:#fff">
-	<h1 style="color:#fff" class="heading">Hello World</h1>
+	<div id="hide-parent">
+
+		<!-- Bad contrast -->
+		<h1 style="color:#fff" class="heading">Hello World</h1>
+
+		<!-- Heading with no content -->
+		<h2></h2>
+
+		<!-- No alt attribute -->
+		<img src="/path/to/image.jpg" />
+
+		<!-- Link only contains image and image has no alt attribute -->
+		<a href="http://pa11y.org/">
+			<img src="http://pa11y.org/false-img.jpg"/>
+		</a>
+
+		<!-- No link content -->
+		<a href="http://www.nature.com/"></a>
+
+		<!-- No title attribute -->
+		<iframe src="http://pa11y.org/"></iframe>
+
+		<!-- Duplicate ID -->
+		<p id="para">foo</p>
+		<p id="para">bar</p>
+
+		<form action="">
+			<!-- No label -->
+			<input id="input" name="input" value="" />
+			<!-- No submit -->
+		</form>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
The `hide-elements` options was broken due to a misunderstanding of how
`HTML_codeSniffer` worked.

This change moves away from relying on `HTML_codeSniffer` for this
feature and instead filters out errors that are unwanted.