### PR TITLE
Deprecate Version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ We also maintain a [migration guide](MIGRATION.md) to help you migrate.
 | :heart:         | 4             | N/A                | 4+               | N/A              |
 | :hourglass:     | 3             | 3.8                | 0.12–6           | 2016-12-05       |
 | :hourglass:     | 2             | 2.4                | 0.10–0.12        | 2016-10-16       |
-| :hourglass:     | 1             | 1.7                | 0.10             | 2016-06-08       |
+| :skull:         | 1             | 1.7                | 0.10             | 2016-06-08       |
 
 If you're opening issues related to these, please mention the version that the issue relates to.
 


### PR DESCRIPTION
We've hit the end of support date for Pa11y 1.x. Switching the emoji 👍💀 