### PR TITLE
Upgrade mocha to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"istanbul": "~0.3",
 		"jscs": "^2",
 		"jshint": "^2",
-		"mocha": "^2",
+		"mocha": "^3",
 		"mockery": "~1.4",
 		"proclaim": "^3",
 		"sinon": "^1"


### PR DESCRIPTION
This fixed a security vuln with versions of minimatch older than
3.0.2. Minimatch is one of mocha's dependencies.

Older versions of minimatch (0.3.0 and 2.0.10, both vulnerable) are
still being pulled as dependencies of jshint. Jshint has fixed this
in master but a new version containing the fix hasn't been released
yet.

This shouldn't be much of a problem in production environments
anyway, as they are both devDependencies.

All the instances of `minimatch` in the dependencies after this fix:
```
$ npm list minimatch
pa11y@4.0.0 /Users/jose.bolos/repositories/pa11y/pa11y
├─┬ jscs@2.11.0
│ ├── minimatch@3.0.3
│ ├─┬ prompt@0.2.14
│ │ └─┬ utile@0.2.1
│ │   └─┬ rimraf@2.5.4
│ │     └─┬ glob@7.0.5
│ │       └── minimatch@3.0.3
│ └─┬ vow-fs@0.3.6
│   └─┬ glob@7.0.5
│     └── minimatch@3.0.3
├─┬ jshint@2.9.2
│ ├─┬ cli@0.6.6
│ │ └─┬ glob@3.2.11
│ │   └── minimatch@0.3.0
│ └── minimatch@2.0.10
└─┬ mocha@3.0.2
  └─┬ glob@7.0.5
    └── minimatch@3.0.3
```

