### PR TITLE
Install phantomjs as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ test.run('nature.com', function (error, results) {
 
 ---
 
-✨ 🔜 ✨ The Pa11y team is very excited to announce plans for the successor to Pa11y Dashboard and Pa11y Webservice, codename "Sidekick". Help us define the features that you want to see by visiting the [proposal][sidekick-proposal]. ✨  
+✨ 🔜 ✨ The Pa11y team is very excited to announce plans for the successor to Pa11y Dashboard and Pa11y Webservice, codename "Sidekick". Help us define the features that you want to see by visiting the [proposal][sidekick-proposal]. ✨
 
 ---
 
@@ -52,26 +52,25 @@ Table Of Contents
 Requirements
 ------------
 
-Pa11y requires [Node.js][node] 4+ and [PhantomJS][phantom] (latest stable version recommended) to run.
+Pa11y requires [Node.js][node] 4+ to run.
 
 ### OS X
 
-On a Mac, you can install the required dependencies with [Homebrew][brew]:
+On a Mac, you can install the required dependency with [Homebrew][brew]:
 
 ```sh
 $ brew install node
-$ brew install phantomjs
 ```
 
-Alternatively download pre-built packages from the [Node.js][node] and [PhantomJS][phantom] websites.
+Alternatively download pre-built packages from the [Node.js][node] website.
 
 ### Linux
 
-Depending on your flavour of Linux, you should be able to use a package manager to install the required dependencies. Alternatively download pre-built packages from the [Node.js][node] and [PhantomJS][phantom] websites.
+Depending on your flavour of Linux, you should be able to use a package manager to install the required dependency. Alternatively download pre-built packages from the [Node.js][node] website.
 
 ### Windows
 
-Windows users approach with caution – we've been able to get Pa11y running (Windows 7, Node 4) but only after installing Visual Studio and the Windows SDK (as well as Git, Python and PhantomJS). The [Windows installation instructions for node-gyp][windows-install] are a good place to start.
+Windows users approach with caution – we've been able to get Pa11y running (Windows 7, Node 4) but only after installing Visual Studio and the Windows SDK (as well as Git, and Python). The [Windows installation instructions for node-gyp][windows-install] are a good place to start.
 
 If you run into following error:
 
@@ -196,7 +195,7 @@ or by using the flag mutiple times:
 pa11y --ignore warning --ignore notice nature.com
 ```
 
-Pa11y can also ignore notices, warnings, and errors up to a threshold number. This might be useful if you're using CI and don't want to break your build. The following example will return exit code 0 on a page with 9 errors, and return exit code 2 on a page with 11 errors. 
+Pa11y can also ignore notices, warnings, and errors up to a threshold number. This might be useful if you're using CI and don't want to break your build. The following example will return exit code 0 on a page with 9 errors, and return exit code 2 on a page with 11 errors.
 
 ```
 pa11y --threshold 10 nature.com
@@ -788,7 +787,7 @@ If you're opening issues related to these, please mention the version that the i
 License
 -------
 
-Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].  
+Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].
 Copyright &copy; 2016, Springer Nature
 
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -7,6 +7,7 @@ var lowercase = require('lower-case');
 var pkg = require('../package.json');
 var truffler = require('truffler');
 var trufflerPkg = require('truffler/package.json');
+var phantomjsPath = require('phantomjs-prebuilt').path;
 
 module.exports = pa11y;
 module.exports.defaults = {
@@ -31,7 +32,8 @@ module.exports.defaults = {
 		parameters: {
 			'ignore-ssl-errors': 'true',
 			'ssl-protocol': 'tlsv1'
-		}
+		},
+		path: phantomjsPath
 	},
 	rootElement: null,
 	standard: 'WCAG2AA',

--- a/package.json
+++ b/package.json
@@ -1,58 +1,59 @@
 {
-	"name": "pa11y",
-	"version": "4.0.1",
-
-	"description": "Pa11y is your automated accessibility testing pal",
-	"keywords": [ "accessibility", "analysis", "cli", "report" ],
-
-	"author": "Nature Publishing Group",
-	"contributors": [
-		"Rowan Manning (http://rowanmanning.com/)",
-		"Whymarrh Whitby (http://whymarrh.com/)",
-		"Stephen Mathieson (http://www.stephenmathieson.com/)",
-		"Alex Soble (http://www.alexsoble.com/)",
-		"Charlie Brown (http://www.carbonatethis.com/)",
-		"Hollie Kay (http://www.hollsk.co.uk/)",
-		"Adam Tavener (http://www.tavvy.co.uk/)",
-		"Glynn Phillips (http://www.glynnphillips.co.uk/)"
-	],
-
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/pa11y/pa11y.git"
-	},
-	"homepage": "https://github.com/pa11y/pa11y",
-	"bugs": "https://github.com/pa11y/pa11y/issues",
-	"license": "LGPL-3.0",
-
-	"engines": {
-		"node": ">=4"
-	},
-	"dependencies": {
-		"async": "~1.4",
-		"bfj": "~1.2",
-		"chalk": "~1.1",
-		"commander": "~2.8",
-		"lower-case": "~1.1",
-		"node.extend": "~1.1",
-		"once": "~1.3",
-		"truffler": "~2.2"
-	},
-	"devDependencies": {
-		"istanbul": "~0.3",
-		"jscs": "^2",
-		"jshint": "^2",
-		"mocha": "^3",
-		"mockery": "~1.4",
-		"proclaim": "^3",
-		"sinon": "^1"
-	},
-
-	"main": "./lib/pa11y.js",
-	"bin": {
-		"pa11y": "./bin/pa11y"
-	},
-	"scripts": {
-		"test": "make ci"
-	}
+  "name": "pa11y",
+  "version": "4.0.1",
+  "description": "Pa11y is your automated accessibility testing pal",
+  "keywords": [
+    "accessibility",
+    "analysis",
+    "cli",
+    "report"
+  ],
+  "author": "Nature Publishing Group",
+  "contributors": [
+    "Rowan Manning (http://rowanmanning.com/)",
+    "Whymarrh Whitby (http://whymarrh.com/)",
+    "Stephen Mathieson (http://www.stephenmathieson.com/)",
+    "Alex Soble (http://www.alexsoble.com/)",
+    "Charlie Brown (http://www.carbonatethis.com/)",
+    "Hollie Kay (http://www.hollsk.co.uk/)",
+    "Adam Tavener (http://www.tavvy.co.uk/)",
+    "Glynn Phillips (http://www.glynnphillips.co.uk/)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pa11y/pa11y.git"
+  },
+  "homepage": "https://github.com/pa11y/pa11y",
+  "bugs": "https://github.com/pa11y/pa11y/issues",
+  "license": "LGPL-3.0",
+  "engines": {
+    "node": ">=4"
+  },
+  "dependencies": {
+    "async": "~1.4",
+    "bfj": "~1.2",
+    "chalk": "~1.1",
+    "commander": "~2.8",
+    "lower-case": "~1.1",
+    "node.extend": "~1.1",
+    "once": "~1.3",
+    "phantomjs-prebuilt": "^2.1.12",
+    "truffler": "~2.2"
+  },
+  "devDependencies": {
+    "istanbul": "~0.3",
+    "jscs": "^2",
+    "jshint": "^2",
+    "mocha": "^3",
+    "mockery": "~1.4",
+    "proclaim": "^3",
+    "sinon": "^1"
+  },
+  "main": "./lib/pa11y.js",
+  "bin": {
+    "pa11y": "./bin/pa11y"
+  },
+  "scripts": {
+    "test": "make ci"
+  }
 }


### PR DESCRIPTION
I thought it might be a good idea to have PhantomJS be installed automatically when installing Pa11y.

Users are still able to override the binary path used for phantomJS if they want to supply their own PhantomJS binary.
