### PR TITLE
Remove ssl-protocol from default phantom config

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -30,8 +30,7 @@ module.exports.defaults = {
 	phantom: {
 		onStdout: /* istanbul ignore next */ function() {},
 		parameters: {
-			'ignore-ssl-errors': 'true',
-			'ssl-protocol': 'tlsv1'
+			'ignore-ssl-errors': 'true'
 		},
 		path: phantomjsPath
 	},

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -103,10 +103,6 @@ describe('lib/pa11y', function() {
 			assert.strictEqual(defaults.phantom.parameters['ignore-ssl-errors'], 'true');
 		});
 
-		it('should have a `phantom.parameters[\'ssl-protocol\']` property', function() {
-			assert.strictEqual(defaults.phantom.parameters['ssl-protocol'], 'tlsv1');
-		});
-
 		it('should have a `standard` property', function() {
 			assert.strictEqual(defaults.standard, 'WCAG2AA');
 		});


### PR DESCRIPTION
Using tlsv1 as default causes a problem on sites that have tlsv1
disabled (but support for example tls1.1 or tls1.2) as phantomjs
will fail to load the page without explanation.

Reverts #62 