### PR TITLE
Add a proposal and working code for "actions", a new automation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,10 +593,13 @@ Actions are additional interactions that you can make Pa11y perform before the t
 ```js
 pa11y({
     actions: [
-        'set field #username to exampleUser',
-        'set field #password to password1234',
-        'click element #submit',
-        'wait for path to be /myaccount'
+        'click element #tab-1',
+        'set field #fullname to John Doe',
+        'check field #terms-and-conditions',
+        'uncheck field #subscribe-to-marketing',
+        'wait for fragment to be #page-2',
+        'wait for path to be /login',
+        'wait for url to be https://example.com/'
     ]
 });
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Table Of Contents
 - [Command-Line Interface](#command-line-interface)
 - [JavaScript Interface](#javascript-interface)
 - [Configuration](#configuration)
+- [Actions](#actions)
 - [Examples](#examples)
 - [Common Questions](#common-questions)
 - [Contributing](#contributing)
@@ -325,6 +326,25 @@ test.run('http://www.nature.com/', {
 
 Below is a reference of all the options that are available:
 
+### `actions` (array) **BETA**
+
+Actions to be run before Pa11y tests the page. There are quite a few different actions available in Pa11y, the [Actions documentation](#actions) outlines each of them.
+
+**Note:** actions are currently in a beta state and the API may change while we gather feedback.
+
+```js
+pa11y({
+    actions: [
+        'set field #username to exampleUser',
+        'set field #password to password1234',
+        'click element #submit',
+        'wait for path to be /myaccount'
+    ]
+});
+```
+
+Defaults to an empty array.
+
 ### `allowedStandards` (array)
 
 The accessibility standards that are allowed to be used. This can be modified to allow for custom HTML CodeSniffer standards.
@@ -339,7 +359,9 @@ Defaults to `Section508`, `WCAG2A`, `WCAG2AA`, and `WCAG2AAA`.
 
 ### `beforeScript` (function)
 
-A function to be run before Pa11y tests the page. The function accepts three parameters;
+**Note:** unless you're doing something particularly complicated, it's much easier and less error prone to use [actions](#actions) rather than `beforeScript`. If you specify both, the `beforeScript` will be dropped with a warning.
+
+A function to be run before Pa11y tests the page. The function accepts three parameters:
 
 - `page` is the phantomjs page object, [documentation for the phantom bridge can be found here][phantom-node-options]
 - `options` is the finished options object used to configure pa11y
@@ -348,10 +370,10 @@ A function to be run before Pa11y tests the page. The function accepts three par
 ```js
 pa11y({
     beforeScript: function(page, options, next) {
-		// Make changes to the page
-		// When finished call next to continue running Pa11y tests
-		next();
-	}
+        // Make changes to the page
+        // When finished call next to continue running Pa11y tests
+        next();
+    }
 });
 ```
 
@@ -364,7 +386,7 @@ Elements matching this selector will be hidden from testing by styling them with
 
 ```js
 pa11y({
-	hideElements: '.advert, #modal, div[aria-role=presentation]'
+    hideElements: '.advert, #modal, div[aria-role=presentation]'
 });
 ```
 
@@ -563,6 +585,80 @@ pa11y({
 Defaults to `null`.
 
 
+Actions
+-------
+
+Actions are additional interactions that you can make Pa11y perform before the tests are run. They allow you to do things like click on a button, enter a value in a form, wait for a redirect, or wait for the URL fragment to change:
+
+```js
+pa11y({
+    actions: [
+        'set field #username to exampleUser',
+        'set field #password to password1234',
+        'click element #submit',
+        'wait for path to be /myaccount'
+    ]
+});
+```
+
+Below is a reference of all the available actions and what they do on the page. Some of these take time to complete so you may need to increase the `timeout` option if you have a large set of actions.
+
+### Click Element
+
+This allows you to click an element by passing in a CSS selector. This action takes the form `click element <selector>`. E.g.
+
+```js
+pa11y({
+    actions: [
+        'click element #tab-1'
+    ]
+});
+```
+
+### Set Field Value
+
+This allows you to set the value of a text-based input or select box by passing in a CSS selector and value. This action takes the form `set field <selector> to <value>`. E.g.
+
+```js
+pa11y({
+    actions: [
+        'set field #fullname to John Doe'
+    ]
+});
+```
+
+### Check/Uncheck Field
+
+This allows you to check or uncheck checkbox and radio inputs by passing in a CSS selector. This action takes the form `check field <selector>` or `uncheck field <selector>`. E.g.
+
+```js
+pa11y({
+    actions: [
+        'check field #terms-and-conditions',
+        'uncheck field #subscribe-to-marketing'
+    ]
+});
+```
+
+### Wait For Fragment/Path/URL
+
+This allows you to pause the test until a condition is met, and the page has either a given fragment, path, or URL. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. This action takes one of the forms:
+
+  - `wait for fragment to be <fragment>` (including the preceeding `#`)
+  - `wait for path to be <path>` (including the preceeding `/`)
+  - `wait for url to be <url>`
+
+E.g.
+
+```js
+pa11y({
+    actions: [
+        'wait for path to be /login'
+    ]
+});
+```
+
+
 Examples
 --------
 
@@ -589,6 +685,10 @@ Use [async][async] to run Pa11y on multiple URLs in parallel, with a configurabl
 ```
 node example/multiple-concurrent
 ```
+
+### Actions Example
+
+Step through some actions before Pa11y runs. This example logs into a fictional site then waits until the account page has loaded before running Pa11y. [See the example](example/actions/index.js).
 
 ### Before Script Example
 
@@ -631,44 +731,20 @@ pa11y({
 
 ### How can Pa11y log in if my site has a log in form?
 
-Use the `beforeScript` option either in your JS code or in your config file to input login details and submit the form.
-Once the form has been submitted you will also have to wait until the page you want to test has loaded before calling `next` to run Pa11y.
+Use the [`actions`](#actions) option to specify a series of actions to execute before Pa11y runs the tests:
 
 ```js
 pa11y({
-	beforeScript: function(page, options, next) {
-		var waitUntil = function(condition, retries, waitOver) {
-			page.evaluate(condition, function(error, result) {
-				if (result || retries < 1) {
-					waitOver();
-				} else {
-					retries -= 1;
-					setTimeout(function() {
-						waitUntil(condition, retries, waitOver);
-					}, 200);
-				}
-			});
-		};
-
-		page.evaluate(function() {
-			var user = document.querySelector('#username');
-			var password = document.querySelector('#password');
-			var submit = document.querySelector('#submit');
-
-			user.value = 'exampleUser';
-			password.value = 'password1234';
-
-			submit.click();
-
-		}, function() {
-
-			waitUntil(function() {
-				return window.location.href === 'http://example.com/myaccount';
-			}, 20, next);
-		});
-	}
+    actions: [
+        'set field #username to exampleUser',
+        'set field #password to password1234',
+        'click element #submit',
+        'wait for path to be /myaccount'
+    ]
 });
 ```
+
+You can also use the `beforeScript` option for this, but it can be complicated and error-prone. See the [`beforeScript` example] for more information.
 
 ### How can I use Pa11y with a proxy server?
 
@@ -690,7 +766,7 @@ These match PhantomJS [command-line parameters][phantom-cli]. `proxy-type` can b
 
 ### How can I simulate a user interaction before running Pa11y?
 
-Use the `beforeScript` option either in your JS code or in your config file to simulate the interactions before running Pa11y.
+For simple interactions, we recommend using [actions](#actions). For more complex interactions, use the `beforeScript` option either in your JS code or in your config file to simulate the interactions before running Pa11y.
 
 In this example, additional content is loaded via ajax when a button is clicked.
 Once the content is loaded the `aria-hidden` attribute switches from `true` to `false`.

--- a/example/actions/index.js
+++ b/example/actions/index.js
@@ -1,0 +1,37 @@
+// An example of executing some actions before Pa11y runs.
+// This example logs in to a fictional site then waits
+// until the account page has loaded before running Pa11y.
+//
+// NOTE: This is proposed behaviour, and this example
+// replicates the before-script example
+'use strict';
+
+var pa11y = require('../..');
+
+// Create a test instance with some default options
+var test = pa11y({
+
+	// Log what's happening to the console
+	log: {
+		debug: console.log.bind(console),
+		error: console.error.bind(console),
+		info: console.log.bind(console)
+	},
+
+	// Run some actions before the tests
+	actions: [
+		'set #username to exampleUser',
+		'set #password to password1234',
+		'click #submit',
+		'wait for url to be http://example.com/myaccount'
+	]
+
+});
+
+// Test http://example.com/
+test.run('example.com', function(error, result) {
+	if (error) {
+		return console.error(error.message);
+	}
+	console.log(result);
+});

--- a/example/actions/index.js
+++ b/example/actions/index.js
@@ -1,9 +1,6 @@
 // An example of executing some actions before Pa11y runs.
 // This example logs in to a fictional site then waits
 // until the account page has loaded before running Pa11y.
-//
-// NOTE: This is proposed behaviour, and this example
-// replicates the before-script example
 'use strict';
 
 var pa11y = require('../..');
@@ -20,9 +17,9 @@ var test = pa11y({
 
 	// Run some actions before the tests
 	actions: [
-		'set #username to exampleUser',
-		'set #password to password1234',
-		'click #submit',
+		'set field #username to exampleUser',
+		'set field #password to password1234',
+		'click element #submit',
 		'wait for url to be http://example.com/myaccount'
 	]
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -1,0 +1,173 @@
+'use strict';
+
+module.exports = buildAction;
+
+// This function returns a new function, turning an action string
+// into code that can be used by Pa11y
+function buildAction(browser, page, options, actionString) {
+
+	// Find the first action that matches the given action string
+	var actionBuilder = module.exports.allowedActions.find(function(allowedAction) {
+		return allowedAction.match.test(actionString);
+	});
+
+	// Get the action runner, the function that we'll
+	// actually run on the page
+	var actionRunner;
+	if (actionBuilder) {
+		actionRunner = actionBuilder.build(browser, page, options, actionString.match(actionBuilder.match));
+	}
+
+	// Return a function which logs and runs the action
+	return function(done) {
+		if (!actionRunner) {
+			return done(new Error('Failed action: "' + actionString + '" cannot be resolved'));
+		}
+		options.log.debug('Running action: ' + actionString);
+		actionRunner(function(error) {
+			if (!error) {
+				options.log.debug('  ✔︎ action complete');
+			}
+			done(error);
+		});
+	};
+}
+
+module.exports.allowedActions = [
+
+	// Action to click an element
+	// E.g. "click .sign-in-button"
+	{
+		name: 'click-element',
+		match: /^click( element)? (.+)$/i,
+		build: function(browser, page, options, matches) {
+			var actionOptions = {
+				selector: matches[2]
+			};
+
+			return function(done) {
+				page.evaluate(function(actionOptions) {
+					var target = document.querySelector(actionOptions.selector);
+					if (target) {
+						target.click();
+					}
+					return Boolean(target);
+				}, actionOptions, function(error, result) {
+					if (!result) {
+						return done(new Error('Failed action: no element matching selector "' + actionOptions.selector + '"'));
+					}
+					done();
+				});
+			};
+		}
+	},
+
+	// Action to set an input field value
+	// E.g. "set field #username to example"
+	{
+		name: 'set-field-value',
+		match: /^set( field)? (.+) to (.+)$/i,
+		build: function(browser, page, options, matches) {
+			var actionOptions = {
+				selector: matches[2],
+				value: matches[3]
+			};
+
+			return function(done) {
+				page.evaluate(function(actionOptions) {
+					var target = document.querySelector(actionOptions.selector);
+					if (target) {
+						target.value = actionOptions.value;
+					}
+					return Boolean(target);
+				}, actionOptions, function(error, result) {
+					if (!result) {
+						return done(new Error('Failed action: no element matching selector "' + actionOptions.selector + '"'));
+					}
+					done();
+				});
+			};
+		}
+	},
+
+	// Action to check or uncheck a checkbox/radio input
+	// E.g. "check field #example"
+	// E.g. "uncheck field #example"
+	{
+		name: 'check-field',
+		match: /^(check|uncheck)( field)? (.+)$/i,
+		build: function(browser, page, options, matches) {
+			var actionOptions = {
+				checked: true,
+				selector: matches[3]
+			};
+			if (matches[1] === 'uncheck') {
+				actionOptions.checked = false;
+			}
+
+			return function(done) {
+				page.evaluate(function(actionOptions) {
+					var target = document.querySelector(actionOptions.selector);
+					if (target) {
+						target.checked = actionOptions.checked;
+					}
+					return Boolean(target);
+				}, actionOptions, function(error, result) {
+					if (!result) {
+						return done(new Error('Failed action: no element matching selector "' + actionOptions.selector + '"'));
+					}
+					done();
+				});
+			};
+		}
+	},
+
+	// Action which waits for the URL, path, or fragment to change to the given value
+	// E.g. "wait for fragment to be #example"
+	// E.g. "wait for path to be /example"
+	// E.g. "wait for url to be https://example.com/"
+	{
+		name: 'wait-for-url',
+		match: /^wait for (fragment|hash|path|url)( to be)? (.+)$/i,
+		build: function(browser, page, options, matches) {
+			var actionOptions = {
+				expectedValue: matches[3],
+				subject: matches[1]
+			};
+
+			function waitForValue(expectedValue, done) {
+				page.evaluate(function(actionOptions) {
+					/* eslint complexity: 0 */
+					var value;
+					switch (actionOptions.subject) {
+						case 'fragment':
+						case 'hash':
+							value = window.location.hash;
+							break;
+						case 'path':
+							value = window.location.pathname;
+							break;
+						case 'url':
+							value = window.location.href;
+							break;
+					}
+					return value;
+				}, actionOptions, function(error, result) {
+					options.log.debug('  … waiting ("' + result + '")');
+					if (result === actionOptions.expectedValue) {
+						done();
+					} else {
+						setTimeout(function() {
+							waitForValue(actionOptions.expectedValue, done);
+						}, 200);
+					}
+				});
+			};
+
+			return function(done) {
+				waitForValue(actionOptions.expectedValue, done);
+			};
+		}
+	}
+
+];

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var buildAction = require('./action');
 var once = require('once');
 var async = require('async');
 var extend = require('node.extend');
@@ -11,6 +12,7 @@ var phantomjsPath = require('phantomjs-prebuilt').path;
 
 module.exports = pa11y;
 module.exports.defaults = {
+	actions: [],
 	beforeScript: null,
 	hideElements: null,
 	htmlcs: __dirname + '/vendor/HTMLCS.js',
@@ -70,14 +72,33 @@ function testPage(browser, page, options, done) {
 
 	async.waterfall([
 
-		// Run beforeScript
+		// Run beforeScript function
 		function(next) {
 			if (typeof options.beforeScript !== 'function') {
 				return next();
+			} else if (options.actions.length) {
+				options.log.info('beforeScript cannot be used in combination with actions, ignoring beforeScript');
+				return next();
 			}
-
 			options.log.debug('Running beforeScript');
 			options.beforeScript(page, options, next);
+		},
+
+		// Run actions
+		function(next) {
+			if (!options.actions.length) {
+				return next();
+			}
+			options.log.info('Running actions');
+			var actions = options.actions.map(function(actionString) {
+				return buildAction(browser, page, options, actionString);
+			});
+			async.series(actions, function(error) {
+				if (!error) {
+					options.log.info('Finished running actions');
+				}
+				next(error);
+			});
 		},
 
 		// Inject HTML CodeSniffer

--- a/test/unit/lib/action.js
+++ b/test/unit/lib/action.js
@@ -1,0 +1,906 @@
+/* eslint-disable one-var, max-len, max-statements */
+'use strict';
+
+var assert = require('proclaim');
+var sinon = require('sinon');
+
+describe('lib/action', function() {
+	var buildAction;
+
+	beforeEach(function() {
+		buildAction = require('../../../lib/action');
+	});
+
+	it('should be a function', function() {
+		assert.isFunction(buildAction);
+	});
+
+	it('has an `allowedActions` property', function() {
+		assert.isArray(buildAction.allowedActions);
+	});
+
+	describe('buildAction(browser, page, options, actionString)', function() {
+		var browser;
+		var mockActionRunner1;
+		var mockActionRunner2;
+		var options;
+		var page;
+		var returnedValue;
+
+		beforeEach(function() {
+			browser = {
+				isMockBrowser: true
+			};
+			options = {
+				log: {
+					debug: sinon.spy()
+				}
+			};
+			page = {
+				isMockPage: true
+			};
+			mockActionRunner1 = sinon.stub().yieldsAsync();
+			mockActionRunner2 = sinon.stub().yieldsAsync();
+			buildAction.allowedActions = [
+				{
+					match: /^foo/,
+					build: sinon.stub().returns(mockActionRunner1)
+				},
+				{
+					match: /^bar/,
+					build: sinon.stub().returns(mockActionRunner2)
+				}
+			];
+			returnedValue = buildAction(browser, page, options, 'bar 123');
+		});
+
+		it('calls the build function that matches the given `actionString`', function() {
+			var action = buildAction.allowedActions[1];
+			assert.notCalled(buildAction.allowedActions[0].build);
+			assert.calledOnce(action.build);
+			assert.calledWith(action.build, browser, page, options);
+			assert.deepEqual(action.build.firstCall.args[3], [
+				'bar'
+			]);
+		});
+
+		it('returns a function', function() {
+			assert.isFunction(returnedValue);
+		});
+
+		describe('returned function', function() {
+
+			beforeEach(function(done) {
+				returnedValue(done);
+			});
+
+			it('logs that the action is running', function() {
+				assert.calledWith(options.log.debug, 'Running action: bar 123');
+			});
+
+			it('calls the built action runner', function() {
+				assert.calledOnce(mockActionRunner2);
+			});
+
+			it('logs that the action is complete', function() {
+				assert.calledWith(options.log.debug, '  ✔︎ action complete');
+			});
+
+		});
+
+		describe('when `actionString` does not match an allowed action', function() {
+
+			beforeEach(function() {
+				options.log.debug.reset();
+				mockActionRunner2.reset();
+				buildAction.allowedActions[1].build.reset();
+				returnedValue = buildAction(browser, page, options, 'baz 123');
+			});
+
+			describe('returned function', function() {
+				var caughtError;
+
+				beforeEach(function(done) {
+					returnedValue(function(error) {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('calls back with an error detailing the unresolved action', function() {
+					assert.instanceOf(caughtError, Error);
+					assert.strictEqual(caughtError.message, 'Failed action: "baz 123" cannot be resolved');
+				});
+
+				it('does not log that the action is running', function() {
+					assert.neverCalledWith(options.log.debug, 'Running action: baz 123');
+				});
+
+				it('does not call the built action runner', function() {
+					assert.notCalled(mockActionRunner2);
+				});
+
+				it('does not log that the action is complete', function() {
+					assert.neverCalledWith(options.log.debug, '  ✔︎ action complete');
+				});
+
+			});
+
+		});
+
+		describe('when the action runner calls back with an error', function() {
+			var actionRunnerError;
+
+			beforeEach(function() {
+				options.log.debug.reset();
+				mockActionRunner2.reset();
+				actionRunnerError = new Error('action-runner-error');
+				mockActionRunner2.yieldsAsync(actionRunnerError);
+				returnedValue = buildAction(browser, page, options, 'bar 123');
+			});
+
+			describe('returned function', function() {
+				var caughtError;
+
+				beforeEach(function(done) {
+					returnedValue(function(error) {
+						caughtError = error;
+						done();
+					});
+				});
+
+				it('logs that the action is running', function() {
+					assert.calledWith(options.log.debug, 'Running action: bar 123');
+				});
+
+				it('calls the built action runner', function() {
+					assert.calledOnce(mockActionRunner2);
+				});
+
+				it('calls back with the action runner\'s error', function() {
+					assert.strictEqual(caughtError, actionRunnerError);
+				});
+
+				it('does not log that the action is complete', function() {
+					assert.neverCalledWith(options.log.debug, '  ✔︎ action complete');
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('click-element action', function() {
+		var action;
+
+		beforeEach(function() {
+			action = buildAction.allowedActions.find(function(allowedAction) {
+				return allowedAction.name === 'click-element';
+			});
+		});
+
+		it('should have a name property', function() {
+			assert.strictEqual(action.name, 'click-element');
+		});
+
+		it('should have a match property', function() {
+			assert.instanceOf(action.match, RegExp);
+		});
+
+		describe('.match', function() {
+
+			it('should match all of the expected action strings', function() {
+				assert.deepEqual('click .foo'.match(action.match), [
+					'click .foo',
+					undefined,
+					'.foo'
+				]);
+				assert.deepEqual('click element .foo'.match(action.match), [
+					'click element .foo',
+					' element',
+					'.foo'
+				]);
+				assert.deepEqual('click element .foo .bar .baz'.match(action.match), [
+					'click element .foo .bar .baz',
+					' element',
+					'.foo .bar .baz'
+				]);
+			});
+
+		});
+
+		it('should have a build method', function() {
+			assert.isFunction(action.build);
+		});
+
+		describe('.build(browser, page, options, matches)', function() {
+			var matches;
+			var page;
+			var returnedValue;
+
+			beforeEach(function() {
+				page = {
+					evaluate: sinon.stub().callsArgWithAsync(2, null, true)
+				};
+				matches = 'click element foo'.match(action.match);
+				returnedValue = action.build({}, page, {}, matches);
+			});
+
+			it('returns a function', function() {
+				assert.isFunction(returnedValue);
+			});
+
+			describe('returned function', function() {
+
+				beforeEach(function(done) {
+					returnedValue(done);
+				});
+
+				it('calls `page.evaluate` with a function and some action options', function() {
+					assert.calledOnce(page.evaluate);
+					assert.isFunction(page.evaluate.firstCall.args[0]);
+					assert.deepEqual(page.evaluate.firstCall.args[1], {
+						selector: matches[2]
+					});
+				});
+
+				describe('evaluate function', function() {
+					var element;
+					var evaluateFunction;
+
+					beforeEach(function() {
+						evaluateFunction = page.evaluate.firstCall.args[0];
+						element = {
+							click: sinon.spy()
+						};
+						global.document = {
+							querySelector: sinon.stub().returns(element)
+						};
+						returnedValue = evaluateFunction({
+							selector: 'mock-selector'
+						});
+					});
+
+					afterEach(function() {
+						delete global.document;
+					});
+
+					it('selects an element with the given selector', function() {
+						assert.calledOnce(document.querySelector);
+						assert.calledWithExactly(document.querySelector, 'mock-selector');
+					});
+
+					it('clicks the selected element', function() {
+						assert.calledOnce(element.click);
+					});
+
+					it('returns `true`', function() {
+						assert.isTrue(returnedValue);
+					});
+
+					describe('when no element matches the given selector', function() {
+
+						beforeEach(function() {
+							element.click.reset();
+							global.document.querySelector.returns(null);
+							returnedValue = evaluateFunction({
+								selector: 'mock-selector'
+							});
+						});
+
+						it('does not click the selected element', function() {
+							assert.notCalled(element.click);
+						});
+
+						it('returns `false`', function() {
+							assert.isFalse(returnedValue);
+						});
+
+					});
+
+				});
+
+				describe('when `page.evaluate` calls back with a falsy result', function() {
+					var caughtError;
+
+					beforeEach(function(done) {
+						page.evaluate.callsArgWithAsync(2, null, false);
+
+						returnedValue(function(error) {
+							caughtError = error;
+							done();
+						});
+					});
+
+					it('calls back with an error', function() {
+						assert.instanceOf(caughtError, Error);
+						assert.strictEqual(caughtError.message, 'Failed action: no element matching selector "foo"');
+					});
+
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('set-field-value action', function() {
+		var action;
+
+		beforeEach(function() {
+			action = buildAction.allowedActions.find(function(allowedAction) {
+				return allowedAction.name === 'set-field-value';
+			});
+		});
+
+		it('should have a name property', function() {
+			assert.strictEqual(action.name, 'set-field-value');
+		});
+
+		it('should have a match property', function() {
+			assert.instanceOf(action.match, RegExp);
+		});
+
+		describe('.match', function() {
+
+			it('should match all of the expected action strings', function() {
+				assert.deepEqual('set .foo to bar'.match(action.match), [
+					'set .foo to bar',
+					undefined,
+					'.foo',
+					'bar'
+				]);
+				assert.deepEqual('set field .foo to bar'.match(action.match), [
+					'set field .foo to bar',
+					' field',
+					'.foo',
+					'bar'
+				]);
+				assert.deepEqual('set field .foo .bar .baz to hello world'.match(action.match), [
+					'set field .foo .bar .baz to hello world',
+					' field',
+					'.foo .bar .baz',
+					'hello world'
+				]);
+			});
+
+		});
+
+		it('should have a build method', function() {
+			assert.isFunction(action.build);
+		});
+
+		describe('.build(browser, page, options, matches)', function() {
+			var matches;
+			var page;
+			var returnedValue;
+
+			beforeEach(function() {
+				page = {
+					evaluate: sinon.stub().callsArgWithAsync(2, null, true)
+				};
+				matches = 'set field foo to bar'.match(action.match);
+				returnedValue = action.build({}, page, {}, matches);
+			});
+
+			it('returns a function', function() {
+				assert.isFunction(returnedValue);
+			});
+
+			describe('returned function', function() {
+
+				beforeEach(function(done) {
+					returnedValue(done);
+				});
+
+				it('calls `page.evaluate` with a function and some action options', function() {
+					assert.calledOnce(page.evaluate);
+					assert.isFunction(page.evaluate.firstCall.args[0]);
+					assert.deepEqual(page.evaluate.firstCall.args[1], {
+						selector: matches[2],
+						value: matches[3]
+					});
+				});
+
+				describe('evaluate function', function() {
+					var element;
+					var evaluateFunction;
+
+					beforeEach(function() {
+						evaluateFunction = page.evaluate.firstCall.args[0];
+						element = {};
+						global.document = {
+							querySelector: sinon.stub().returns(element)
+						};
+						returnedValue = evaluateFunction({
+							selector: 'mock-selector',
+							value: 'mock-value'
+						});
+					});
+
+					afterEach(function() {
+						delete global.document;
+					});
+
+					it('selects an element with the given selector', function() {
+						assert.calledOnce(document.querySelector);
+						assert.calledWithExactly(document.querySelector, 'mock-selector');
+					});
+
+					it('sets the element value', function() {
+						assert.strictEqual(element.value, 'mock-value');
+					});
+
+					it('returns `true`', function() {
+						assert.isTrue(returnedValue);
+					});
+
+					describe('when no element matches the given selector', function() {
+
+						beforeEach(function() {
+							delete element.value;
+							global.document.querySelector.returns(null);
+							returnedValue = evaluateFunction({
+								selector: 'mock-selector',
+								value: 'mock-value'
+							});
+						});
+
+						it('does not set the element value', function() {
+							assert.isUndefined(element.value);
+						});
+
+						it('returns `false`', function() {
+							assert.isFalse(returnedValue);
+						});
+
+					});
+
+				});
+
+				describe('when `page.evaluate` calls back with a falsy result', function() {
+					var caughtError;
+
+					beforeEach(function(done) {
+						page.evaluate.callsArgWithAsync(2, null, false);
+
+						returnedValue(function(error) {
+							caughtError = error;
+							done();
+						});
+					});
+
+					it('calls back with an error', function() {
+						assert.instanceOf(caughtError, Error);
+						assert.strictEqual(caughtError.message, 'Failed action: no element matching selector "foo"');
+					});
+
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('check-field action', function() {
+		var action;
+
+		beforeEach(function() {
+			action = buildAction.allowedActions.find(function(allowedAction) {
+				return allowedAction.name === 'check-field';
+			});
+		});
+
+		it('should have a name property', function() {
+			assert.strictEqual(action.name, 'check-field');
+		});
+
+		it('should have a match property', function() {
+			assert.instanceOf(action.match, RegExp);
+		});
+
+		describe('.match', function() {
+
+			it('should match all of the expected action strings', function() {
+				assert.deepEqual('check .foo'.match(action.match), [
+					'check .foo',
+					'check',
+					undefined,
+					'.foo'
+				]);
+				assert.deepEqual('check field .foo'.match(action.match), [
+					'check field .foo',
+					'check',
+					' field',
+					'.foo'
+				]);
+				assert.deepEqual('uncheck field .foo .bar .baz'.match(action.match), [
+					'uncheck field .foo .bar .baz',
+					'uncheck',
+					' field',
+					'.foo .bar .baz'
+				]);
+			});
+
+		});
+
+		it('should have a build method', function() {
+			assert.isFunction(action.build);
+		});
+
+		describe('.build(browser, page, options, matches)', function() {
+			var matches;
+			var page;
+			var returnedValue;
+
+			beforeEach(function() {
+				page = {
+					evaluate: sinon.stub().callsArgWithAsync(2, null, true)
+				};
+				matches = 'check field foo'.match(action.match);
+				returnedValue = action.build({}, page, {}, matches);
+			});
+
+			it('returns a function', function() {
+				assert.isFunction(returnedValue);
+			});
+
+			describe('returned function', function() {
+
+				beforeEach(function(done) {
+					returnedValue(done);
+				});
+
+				it('calls `page.evaluate` with a function and some action options', function() {
+					assert.calledOnce(page.evaluate);
+					assert.isFunction(page.evaluate.firstCall.args[0]);
+					assert.deepEqual(page.evaluate.firstCall.args[1], {
+						checked: true,
+						selector: matches[3]
+					});
+				});
+
+				describe('evaluate function', function() {
+					var element;
+					var evaluateFunction;
+
+					beforeEach(function() {
+						evaluateFunction = page.evaluate.firstCall.args[0];
+						element = {};
+						global.document = {
+							querySelector: sinon.stub().returns(element)
+						};
+						returnedValue = evaluateFunction({
+							selector: 'mock-selector',
+							checked: true
+						});
+					});
+
+					afterEach(function() {
+						delete global.document;
+					});
+
+					it('selects an element with the given selector', function() {
+						assert.calledOnce(document.querySelector);
+						assert.calledWithExactly(document.querySelector, 'mock-selector');
+					});
+
+					it('checks the selected element', function() {
+						assert.isTrue(element.checked);
+					});
+
+					it('returns `true`', function() {
+						assert.isTrue(returnedValue);
+					});
+
+					describe('when the checked value is `false`', function() {
+
+						beforeEach(function() {
+							delete element.checked;
+							returnedValue = evaluateFunction({
+								selector: 'mock-selector',
+								checked: false
+							});
+						});
+
+						it('unchecks the selected element', function() {
+							assert.isFalse(element.checked);
+						});
+
+						it('returns `true`', function() {
+							assert.isTrue(returnedValue);
+						});
+
+					});
+
+					describe('when no element matches the given selector', function() {
+
+						beforeEach(function() {
+							delete element.checked;
+							global.document.querySelector.returns(null);
+							returnedValue = evaluateFunction({
+								selector: 'mock-selector',
+								checked: true
+							});
+						});
+
+						it('does not check the selected element', function() {
+							assert.isUndefined(element.checked);
+						});
+
+						it('returns `false`', function() {
+							assert.isFalse(returnedValue);
+						});
+
+					});
+
+				});
+
+				describe('when `page.evaluate` calls back with a falsy result', function() {
+					var caughtError;
+
+					beforeEach(function(done) {
+						page.evaluate.callsArgWithAsync(2, null, false);
+
+						returnedValue(function(error) {
+							caughtError = error;
+							done();
+						});
+					});
+
+					it('calls back with an error', function() {
+						assert.instanceOf(caughtError, Error);
+						assert.strictEqual(caughtError.message, 'Failed action: no element matching selector "foo"');
+					});
+
+				});
+
+			});
+
+			describe('when `matches` indicates that the field should be unchecked', function() {
+
+				beforeEach(function() {
+					matches = 'uncheck field foo'.match(action.match);
+					returnedValue = action.build({}, page, {}, matches);
+				});
+
+				describe('returned function', function() {
+
+					beforeEach(function(done) {
+						page.evaluate.reset();
+						returnedValue(done);
+					});
+
+					it('calls `page.evaluate` with the expected action options', function() {
+						assert.calledOnce(page.evaluate);
+						assert.deepEqual(page.evaluate.firstCall.args[1], {
+							checked: false,
+							selector: matches[3]
+						});
+					});
+
+				});
+
+			});
+
+		});
+
+	});
+
+	describe('wait-for-url action', function() {
+		var action;
+
+		beforeEach(function() {
+			action = buildAction.allowedActions.find(function(allowedAction) {
+				return allowedAction.name === 'wait-for-url';
+			});
+		});
+
+		it('should have a name property', function() {
+			assert.strictEqual(action.name, 'wait-for-url');
+		});
+
+		it('should have a match property', function() {
+			assert.instanceOf(action.match, RegExp);
+		});
+
+		describe('.match', function() {
+
+			it('should match all of the expected action strings', function() {
+				assert.deepEqual('wait for fragment #foo'.match(action.match), [
+					'wait for fragment #foo',
+					'fragment',
+					undefined,
+					'#foo'
+				]);
+				assert.deepEqual('wait for fragment to be #foo'.match(action.match), [
+					'wait for fragment to be #foo',
+					'fragment',
+					' to be',
+					'#foo'
+				]);
+				assert.deepEqual('wait for hash to be #foo'.match(action.match), [
+					'wait for hash to be #foo',
+					'hash',
+					' to be',
+					'#foo'
+				]);
+				assert.deepEqual('wait for path to be /foo'.match(action.match), [
+					'wait for path to be /foo',
+					'path',
+					' to be',
+					'/foo'
+				]);
+				assert.deepEqual('wait for url to be https://example.com/'.match(action.match), [
+					'wait for url to be https://example.com/',
+					'url',
+					' to be',
+					'https://example.com/'
+				]);
+			});
+
+		});
+
+		it('should have a build method', function() {
+			assert.isFunction(action.build);
+		});
+
+		describe('.build(browser, page, options, matches)', function() {
+			var matches;
+			var options;
+			var page;
+			var returnedValue;
+
+			beforeEach(function() {
+				options = {
+					log: {
+						debug: sinon.spy()
+					}
+				};
+				page = {
+					evaluate: sinon.stub().callsArgWithAsync(2, null, 'foo')
+				};
+				matches = 'wait for path to be foo'.match(action.match);
+				returnedValue = action.build({}, page, options, matches);
+			});
+
+			it('returns a function', function() {
+				assert.isFunction(returnedValue);
+			});
+
+			describe('returned function', function() {
+
+				beforeEach(function(done) {
+					returnedValue(done);
+				});
+
+				it('calls `page.evaluate` with a function and some action options', function() {
+					assert.calledOnce(page.evaluate);
+					assert.isFunction(page.evaluate.firstCall.args[0]);
+					assert.deepEqual(page.evaluate.firstCall.args[1], {
+						expectedValue: matches[3],
+						subject: matches[1]
+					});
+				});
+
+				it('logs that the program is waiting', function() {
+					assert.calledWith(options.log.debug, '  … waiting ("foo")');
+				});
+
+				describe('evaluate function', function() {
+					var evaluateFunction;
+
+					beforeEach(function() {
+						evaluateFunction = page.evaluate.firstCall.args[0];
+						global.window = {
+							location: {
+								hash: 'mock-hash',
+								href: 'mock-href',
+								pathname: 'mock-pathname'
+							}
+						};
+					});
+
+					afterEach(function() {
+						delete global.window;
+					});
+
+					describe('when the subject action option is "fragment"', function() {
+
+						beforeEach(function() {
+							returnedValue = evaluateFunction({
+								subject: 'fragment'
+							});
+						});
+
+						it('returns `window.location.hash`', function() {
+							assert.strictEqual(returnedValue, global.window.location.hash);
+						});
+
+					});
+
+					describe('when the subject action option is "hash"', function() {
+
+						beforeEach(function() {
+							returnedValue = evaluateFunction({
+								subject: 'hash'
+							});
+						});
+
+						it('returns `window.location.hash`', function() {
+							assert.strictEqual(returnedValue, global.window.location.hash);
+						});
+
+					});
+
+					describe('when the subject action option is "path"', function() {
+
+						beforeEach(function() {
+							returnedValue = evaluateFunction({
+								subject: 'path'
+							});
+						});
+
+						it('returns `window.location.pathname`', function() {
+							assert.strictEqual(returnedValue, global.window.location.pathname);
+						});
+
+					});
+
+					describe('when the subject action option is "url"', function() {
+
+						beforeEach(function() {
+							returnedValue = evaluateFunction({
+								subject: 'url'
+							});
+						});
+
+						it('returns `window.location.href`', function() {
+							assert.strictEqual(returnedValue, global.window.location.href);
+						});
+
+					});
+
+				});
+
+			});
+
+			describe('when `page.evaluate` calls back with a result that doesn\'t match the expected value', function() {
+
+				beforeEach(function(done) {
+					sinon.stub(global, 'setTimeout').yieldsAsync();
+					page.evaluate.callsArgWithAsync(2, null, 'bar');
+					page.evaluate.onCall(2).callsArgWithAsync(2, null, 'foo');
+					returnedValue(done);
+				});
+
+				afterEach(function() {
+					global.setTimeout.restore();
+				});
+
+				it('sets a timeout', function() {
+					assert.called(global.setTimeout);
+					assert.isFunction(global.setTimeout.firstCall.args[0]);
+					assert.strictEqual(global.setTimeout.firstCall.args[1], 200);
+				});
+
+				it('calls page.evaluate until it calls back with the expected value', function() {
+					assert.calledThrice(page.evaluate);
+					assert.calledThrice(options.log.debug);
+					assert.calledWith(options.log.debug.firstCall, '  … waiting ("bar")');
+					assert.calledWith(options.log.debug.secondCall, '  … waiting ("bar")');
+					assert.calledWith(options.log.debug.thirdCall, '  … waiting ("foo")');
+				});
+
+			});
+
+		});
+
+	});
+
+
+});
+/* eslint-enable one-var, max-len, max-statements */


### PR DESCRIPTION
This is a proposal and working code for "actions", that should hopefully replace the use of `beforeScript` or provide a safer less error-prone alternative. I've added the ability to use predefined (by us) scripts to perform actions on the page before Pa11y runs tests:

```js
pa11y({
    actions: [
        'set field #username to exampleUser',
        'set field #password to password1234',
        'click element #submit',
        'wait for path to be /myaccount'
    ]
});
```

I've added the following actions as a starting point. I'd like to get this in (tagged as a beta feature) then gather wider feedback from the community. I don't think we can predict which actions users need, but I've added enough to perform commonly requested tasks like logging in or clicking an element:

### Click Element

This allows you to click an element by passing in a CSS selector. This action takes the form `click element <selector>`. E.g.

```js
pa11y({
    actions: [
        'click element #tab-1'
    ]
});
```

### Set Field Value

This allows you to set the value of a text-based input or select box by passing in a CSS selector and value. This action takes the form `set field <selector> to <value>`. E.g.

```js
pa11y({
    actions: [
        'set field #fullname to John Doe'
    ]
});
```

### Check/Uncheck Field

This allows you to check or uncheck checkbox and radio inputs by passing in a CSS selector. This action takes the form `check field <selector>` or `uncheck field <selector>`. E.g.

```js
pa11y({
    actions: [
        'check field #terms-and-conditions',
        'uncheck field #subscribe-to-marketing'
    ]
});
```

### Wait For Fragment/Path/URL

This allows you to pause the test until a condition is met, and the page has either a given fragment, path, or URL. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. This action takes one of the forms:

  - `wait for fragment to be <fragment>` (including the preceeding `#`)
  - `wait for path to be <path>` (including the preceeding `/`)
  - `wait for url to be <url>`

E.g.

```js
pa11y({
    actions: [
        'wait for path to be /login'
    ]
});
```

---

This should all be easier to add into the dashboard/webservice without having to think about the security implications of users being able to run arbitrary JS. Also it lowers the barrier to entry for running code before Pa11y – you don't need to understand JS in order to add actions to your config file.

What do people think?