### PR TITLE
Display: Document title in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## 4.1.1 (2016-11-24)
+
+  * Update dependencies
+    * truffler: ~2.3 to ~3.0
+
 ## 4.1.0 (2016-11-21)
 
   * Install PhantomJS as a dependency if the latest version isn't present

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -45,7 +45,7 @@ function pa11y(options) {
 	if (options.allowedStandards.indexOf(options.standard) === -1) {
 		throw new Error('Standard must be one of ' + options.allowedStandards.join(', '));
 	}
-	return truffler(options, testPage.bind(null, options));
+	return truffler(options, testPage);
 }
 
 function defaultOptions(options) {
@@ -54,7 +54,7 @@ function defaultOptions(options) {
 	return options;
 }
 
-function testPage(options, browser, page, done) {
+function testPage(browser, page, options, done) {
 
 	page.onCallback = once(function(result) {
 		if (result instanceof Error) {
@@ -67,6 +67,8 @@ function testPage(options, browser, page, done) {
 	});
 
 	async.waterfall([
+
+		// Run beforeScript
 		function(next) {
 			if (typeof options.beforeScript !== 'function') {
 				return next();
@@ -75,6 +77,7 @@ function testPage(options, browser, page, done) {
 			options.log.debug('Running beforeScript');
 			options.beforeScript(page, options, next);
 		},
+
 		// Inject HTML CodeSniffer
 		function(next) {
 			options.log.debug('Injecting HTML CodeSniffer');

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -63,7 +63,7 @@ function testPage(browser, page, options, done) {
 		if (result.error) {
 			return done(new Error(result.error));
 		}
-		options.log.debug(`Document title: "${result.documentTitle}"`);
+		options.log.debug('Document title: "' + result.documentTitle + '"');
 		done(null, result.messages);
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pa11y",
-	"version": "4.1.0",
+	"version": "4.1.1",
 
 	"description": "Pa11y is your automated accessibility testing pal",
 	"keywords": [ "accessibility", "analysis", "cli", "report" ],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"node.extend": "~1.1",
 		"once": "~1.3",
 		"phantomjs-prebuilt": "^2.1.12",
-		"truffler": "~2.3"
+		"truffler": "~3.0"
 	},
 	"devDependencies": {
 		"istanbul": "~0.3",

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -418,4 +418,34 @@ describe('lib/pa11y', function() {
 
 	});
 
+	describe('testPage function', function() {
+		var expectedResults, options, runResults, testFunction;
+
+		beforeEach(function(done) {
+			options = {
+				log: {
+					debug: sinon.spy()
+				}
+			};
+			pa11y(options);
+
+			expectedResults = {
+				documentTitle: 'quux'
+			};
+			phantom.mockPage.evaluate = sinon.spy(function() {
+				phantom.mockPage.onCallback(expectedResults);
+			});
+
+			testFunction = truffler.firstCall.args[1];
+			done();
+		});
+
+		it('should call debug log with document title', function(done) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error, results) {
+				assert.calledWith(options.log.debug, 'Document title: "quux"');
+				done();
+			});
+		});
+	});
+
 });

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -419,7 +419,7 @@ describe('lib/pa11y', function() {
 	});
 
 	describe('testPage function', function() {
-		var expectedResults, options, runResults, testFunction;
+		var expectedResults, options, testFunction;
 
 		beforeEach(function(done) {
 			options = {
@@ -441,7 +441,7 @@ describe('lib/pa11y', function() {
 		});
 
 		it('should call debug log with document title', function(done) {
-			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error, results) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function() {
 				assert.calledWith(options.log.debug, 'Document title: "quux"');
 				done();
 			});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -195,7 +195,7 @@ describe('lib/pa11y', function() {
 			});
 
 			testFunction = truffler.firstCall.args[1];
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error, results) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error, results) {
 				runResults = results;
 				done(error);
 			});
@@ -213,7 +213,7 @@ describe('lib/pa11y', function() {
 			truffler.reset();
 			pa11y(options);
 			testFunction = truffler.firstCall.args[1];
-			testFunction(phantom.mockBrowser, phantom.mockPage, function() {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, function() {
 				assert.calledOnce(options.beforeScript);
 				assert.strictEqual(options.beforeScript.firstCall.args[0], phantom.mockPage);
 				assert.strictEqual(options.beforeScript.firstCall.args[1], extend.secondCall.returnValue);
@@ -232,7 +232,7 @@ describe('lib/pa11y', function() {
 			truffler.reset();
 			pa11y(options);
 			testFunction = truffler.firstCall.args[1];
-			testFunction(phantom.mockBrowser, phantom.mockPage, function() {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, function() {
 				assert.calledWith(options.log.debug, 'Running beforeScript');
 				done();
 			});
@@ -248,7 +248,7 @@ describe('lib/pa11y', function() {
 		it('should callback with an error if HTML CodeSniffer injection errors', function(done) {
 			var expectedError = new Error('...');
 			phantom.mockPage.injectJs.withArgs(pa11y.defaults.htmlcs).yieldsAsync(expectedError);
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error) {
 				assert.isNotNull(error);
 				assert.strictEqual(error, expectedError);
 				done();
@@ -257,7 +257,7 @@ describe('lib/pa11y', function() {
 
 		it('should callback with an error if HTML CodeSniffer does not inject properly', function(done) {
 			phantom.mockPage.injectJs.withArgs(pa11y.defaults.htmlcs).yieldsAsync(null, false);
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error) {
 				assert.isNotNull(error);
 				assert.strictEqual(error.message, 'Pa11y was unable to inject scripts into the page');
 				done();
@@ -274,7 +274,7 @@ describe('lib/pa11y', function() {
 				phantom.mockPage.injectJs.reset();
 				pa11y(options);
 				testFunction = truffler.firstCall.args[1];
-				testFunction(phantom.mockBrowser, phantom.mockPage, done);
+				testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, done);
 			});
 
 			it('should include the remote HTML CodeSniffer', function() {
@@ -287,7 +287,7 @@ describe('lib/pa11y', function() {
 			it('should callback with an error if HTML CodeSniffer inclusion errors', function(done) {
 				var expectedError = new Error('...');
 				phantom.mockPage.includeJs.withArgs(options.htmlcs).yieldsAsync(expectedError);
-				testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+				testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, function(error) {
 					assert.isNotNull(error);
 					assert.strictEqual(error, expectedError);
 					done();
@@ -296,7 +296,7 @@ describe('lib/pa11y', function() {
 
 			it('should callback with an error if HTML CodeSniffer does not include properly', function(done) {
 				phantom.mockPage.includeJs.withArgs(options.htmlcs).yieldsAsync(null, false);
-				testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+				testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, function(error) {
 					assert.isNotNull(error);
 					assert.strictEqual(error.message, 'Pa11y was unable to include scripts in the page');
 					done();
@@ -314,7 +314,7 @@ describe('lib/pa11y', function() {
 		it('should callback with an error if the pa11y inject script injection errors', function(done) {
 			var expectedError = new Error('...');
 			phantom.mockPage.injectJs.withArgs(injectScriptPath).yieldsAsync(expectedError);
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error) {
 				assert.isNotNull(error);
 				assert.strictEqual(error, expectedError);
 				done();
@@ -323,7 +323,7 @@ describe('lib/pa11y', function() {
 
 		it('should callback with an error if the pa11y inject script does not inject properly', function(done) {
 			phantom.mockPage.injectJs.withArgs(injectScriptPath).yieldsAsync(null, false);
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error) {
 				assert.isNotNull(error);
 				assert.strictEqual(error.message, 'Pa11y was unable to inject scripts into the page');
 				done();
@@ -391,7 +391,7 @@ describe('lib/pa11y', function() {
 			truffler.reset();
 			pa11y(options);
 			testFunction = truffler.firstCall.args[1];
-			testFunction(phantom.mockBrowser, phantom.mockPage, function() {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.secondCall.returnValue, function() {
 				assert.calledWith(options.log.debug, 'Waiting for ' + options.wait + 'ms');
 				done();
 			});
@@ -408,7 +408,7 @@ describe('lib/pa11y', function() {
 			phantom.mockPage.evaluate = sinon.spy(function() {
 				phantom.mockPage.onCallback(expectedResults);
 			});
-			testFunction(phantom.mockBrowser, phantom.mockPage, function(error) {
+			testFunction(phantom.mockBrowser, phantom.mockPage, extend.firstCall.returnValue, function(error) {
 				assert.isNotNull(error);
 				assert.instanceOf(error, Error);
 				assert.strictEqual(error.message, 'foo');


### PR DESCRIPTION
cc @lc512k @rowanmanning 

With `--debug` flag turned on, running `pa11y` will add to the debug logs the document title of the page tested.

This will allow user to ensure that passing tests are not false positives called from error pages which may not cause any pa11y errors/warnings while the actual page might. Naturally, this relies on the website being tested having appropriate document titles when a page errors (but given the variety of forms these may take it still requires human judgement to deduce whether test has been conducted on the intended page).

### Page found
![page-found](https://cloud.githubusercontent.com/assets/10484515/20628879/8eb699a6-b320-11e6-8c36-50b3840bc0e8.png)

### Page not found
![page-not-found](https://cloud.githubusercontent.com/assets/10484515/20628881/937b5c38-b320-11e6-9ea4-a61263412780.png)