### PR TITLE
Upgrade two devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "truffler": "~3.0"
   },
   "devDependencies": {
-    "istanbul": "~0.3",
-    "jscs": "^2",
+    "istanbul": "~0.4",
+    "jscs": "^3",
     "jshint": "^2",
     "mocha": "^3",
     "mockery": "~1.4",


### PR DESCRIPTION
Avoids printing some warnings on `npm install` :warning: 