### PR TITLE
Return: Entire result object (inc. document title)

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -64,7 +64,7 @@ function testPage(browser, page, options, done) {
 			return done(new Error(result.error));
 		}
 		options.log.debug('Document title: "' + result.documentTitle + '"');
-		done(null, result);
+		done(null, result.messages, result.documentTitle);
 	});
 
 	async.waterfall([

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -64,7 +64,7 @@ function testPage(browser, page, options, done) {
 			return done(new Error(result.error));
 		}
 		options.log.debug('Document title: "' + result.documentTitle + '"');
-		done(null, result.messages);
+		done(null, result);
 	});
 
 	async.waterfall([

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -397,7 +397,7 @@ describe('lib/pa11y', function() {
 		});
 
 		it('should callback with the expected results', function() {
-			assert.strictEqual(runResults, expectedResults.messages);
+			assert.strictEqual(runResults, expectedResults);
 		});
 
 		it('should callback with an error if the evaluated script errors', function(done) {

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -397,7 +397,7 @@ describe('lib/pa11y', function() {
 		});
 
 		it('should callback with the expected results', function() {
-			assert.strictEqual(runResults, expectedResults);
+			assert.strictEqual(runResults, expectedResults.messages);
 		});
 
 		it('should callback with an error if the evaluated script errors', function(done) {


### PR DESCRIPTION
cc @rowanmanning @GlynnPhillips @lc512k

The suggested format change of returned might be problematic if other elsewhere requires it in current form (I have only accommodated the change in `pa11y/ci` in this PR: https://github.com/pa11y/ci/pull/9).