### PR TITLE
Add: Verify page flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ If you're opening issues related to these, please mention the version that the i
 License
 -------
 
-Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].
+Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].<br>
 Copyright &copy; 2016, Springer Nature
 
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Usage: pa11y [options] <url>
     -p, --port <port>             the port to run PhantomJS on
     -t, --timeout <ms>            the timeout in milliseconds
     -w, --wait <ms>               the time to wait before running tests in milliseconds
+    -v, --verify-page <string>    HTML string to verify is included in the page source HTML
     -d, --debug                   output debug messages
     -H, --htmlcs <url>            the URL or path to source HTML_CodeSniffer from
     -e, --phantomjs <path>        the path to the phantomjs executable
@@ -549,6 +550,18 @@ pa11y({
 
 Defaults to `0`.
 
+### `verifyPage` (string)
+
+HTML string to verify is included in the page source HTML. Could be used to ascertain that intended page is being tested (as opposed to error page) by using `<title>` tags and content, or that a specific element is present.
+
+```js
+pa11y({
+    verifyPage: '<title>Nature Research: science journals, jobs, information and services.</title>'
+});
+```
+
+Defaults to `null`.
+
 
 Examples
 --------
@@ -764,7 +777,7 @@ If you're opening issues related to these, please mention the version that the i
 License
 -------
 
-Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].  
+Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].
 Copyright &copy; 2016, Springer Nature
 
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Usage: pa11y [options] <url>
     -p, --port <port>             the port to run PhantomJS on
     -t, --timeout <ms>            the timeout in milliseconds
     -w, --wait <ms>               the time to wait before running tests in milliseconds
-    -v, --verify-page <string>    HTML string to verify is included in the page source HTML
+    -v, --verify-page <string>    HTML string to verify is present in the page source HTML
     -d, --debug                   output debug messages
     -H, --htmlcs <url>            the URL or path to source HTML_CodeSniffer from
     -e, --phantomjs <path>        the path to the phantomjs executable
@@ -552,7 +552,7 @@ Defaults to `0`.
 
 ### `verifyPage` (string)
 
-HTML string to verify is included in the page source HTML. Could be used to ascertain that intended page is being tested (as opposed to error page) by using `<title>` tags and content, or that a specific element is present.
+HTML string to verify is present in the page source HTML. Could be used to ascertain that intended page is being tested (as opposed to error page) by using `<title>` tags and content (as below), or that a specific element is present.
 
 ```js
 pa11y({

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -64,6 +64,10 @@ function configureProgram(program) {
 			'the time to wait before running tests in milliseconds'
 		)
 		.option(
+			'-v, --verify-page <string>',
+			'HTML to verify is included in the page'
+		)
+		.option(
 			'-d, --debug',
 			'output debug messages'
 		)
@@ -123,7 +127,8 @@ function processOptions(program) {
 		rootElement: program.rootElement,
 		standard: program.standard,
 		timeout: program.timeout,
-		wait: program.wait
+		wait: program.wait,
+		verifyPage: program.verifyPage
 	});
 
 	if (!program.debug) {

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -65,7 +65,7 @@ function configureProgram(program) {
 		)
 		.option(
 			'-v, --verify-page <string>',
-			'HTML to verify is included in the page'
+			'HTML string to verify is included in the page source HTML'
 		)
 		.option(
 			'-d, --debug',

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -65,7 +65,7 @@ function configureProgram(program) {
 		)
 		.option(
 			'-v, --verify-page <string>',
-			'HTML string to verify is included in the page source HTML'
+			'HTML string to verify is present in the page source HTML'
 		)
 		.option(
 			'-d, --debug',

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -6,7 +6,7 @@ function injectPa11y(window, options, done) {
 	if (options.verifyPage) {
 		var windowHtml = window.document.documentElement.outerHTML;
 		if (!windowHtml.match(new RegExp(options.verifyPage))) {
-			reportError('Page not verified');
+			return reportError('Page not verified');
 		}
 	}
 

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -3,6 +3,13 @@
 /* eslint-disable max-statements */
 function injectPa11y(window, options, done) {
 
+	if (options.verifyPage) {
+		var windowHtml = window.document.documentElement.outerHTML;
+		if (!windowHtml.match(new RegExp(options.verifyPage))) {
+			reportError('Page not verified');
+		}
+	}
+
 	var messageTypeMap = {
 		1: 'error',
 		2: 'warning',

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -6,7 +6,7 @@ function injectPa11y(window, options, done) {
 	if (options.verifyPage) {
 		var windowHtml = window.document.documentElement.outerHTML;
 		if (!windowHtml.match(new RegExp(options.verifyPage))) {
-			return reportError('Page not verified');
+			return reportError('Page not verified - HTML did not contain: "' + options.verifyPage + '"');
 		}
 	}
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -37,7 +37,8 @@ module.exports.defaults = {
 	rootElement: null,
 	standard: 'WCAG2AA',
 	allowedStandards: ['Section508', 'WCAG2A', 'WCAG2AA', 'WCAG2AAA'],
-	wait: 0
+	wait: 0,
+	verifyPage: null
 };
 
 function pa11y(options) {
@@ -141,7 +142,8 @@ function testPage(browser, page, options, done) {
 				ignore: options.ignore,
 				rootElement: options.rootElement,
 				standard: options.standard,
-				wait: options.wait
+				wait: options.wait,
+				verifyPage: options.verifyPage
 			}, next);
 		}
 

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -541,5 +541,26 @@ describe('lib/inject', function() {
 		});
 	});
 
+	describe('verifyPage flag', function() {
+
+		it('should not error when verifyPage value exists in HTML', function(done) {
+			options.verifyPage = '<title>Foo</title>';
+			inject(window, options, function(result) {
+				assert.isUndefined(result.error);
+				done();
+			});
+		});
+
+		it('should error when verifyPage value does not exist in HTML', function(done) {
+			options.verifyPage = '<title>Bar</title>';
+			inject(window, options, function(result) {
+				assert.isDefined(result.error);
+				assert.strictEqual(result.error, 'Page not verified');
+				done();
+			});
+		});
+
+	});
+
 });
 /* eslint-enable one-var, max-len, max-statements */

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -555,7 +555,7 @@ describe('lib/inject', function() {
 			options.verifyPage = '<title>Bar</title>';
 			inject(window, options, function(result) {
 				assert.isDefined(result.error);
-				assert.strictEqual(result.error, 'Page not verified');
+				assert.strictEqual(result.error, 'Page not verified - HTML did not contain: "<title>Bar</title>"');
 				done();
 			});
 		});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -340,6 +340,7 @@ describe('lib/pa11y', function() {
 				],
 				standard: 'Section508',
 				wait: 0,
+				verifyPage: null,
 				rootElement: null
 			});
 			assert.isFunction(phantom.mockPage.evaluate.firstCall.args[2]);

--- a/test/unit/mock/window.js
+++ b/test/unit/mock/window.js
@@ -5,6 +5,9 @@ var sinon = require('sinon');
 module.exports = {
 	callPhantom: sinon.spy(),
 	document: {
+		documentElement: {
+			outerHTML: '<title>Foo</title>'
+		},
 		querySelector: sinon.stub().returns(null),
 		querySelectorAll: sinon.stub().returns([])
 	},


### PR DESCRIPTION
cc @GlynnPhillips @rowanmanning @lc512k

Allows user to add a string of HTML that they expect to be included in the HTML of the page being tested to verify that the intended page is being tested (i.e. not an Application Error page) and/or certain elements are present on the page.

Next step is to add similar flag in `pa11y-ci` that can pass the option through into `pa11y`: https://github.com/pa11y/ci/pull/11.