### PR TITLE
Expose action validation (for use in webservice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ var htmlReporter = require('pa11y/reporter/html');
 var html = htmlReporter.process(results, url);
 ```
 
+### Validating Actions
+
+Pa11y exposes a function which allows you to validate [action](#actions) strings before attempting to use them.
+
+This function accepts an action string and returns a boolean indicating whether the action is valid or not:
+
+```js
+pa11y.validateAction('click element #submit');  // true
+pa11y.validateAction('open the pod bay doors'); // false
+```
+
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ var html = htmlReporter.process(results, url);
 
 Pa11y exposes a function which allows you to validate [action](#actions) strings before attempting to use them.
 
-This function accepts an action string and returns a boolean indicating whether the action is valid or not:
+This function accepts an action string and returns a boolean indicating whether it matches one of the actions that Pa11y supports:
 
 ```js
 pa11y.validateAction('click element #submit');  // true

--- a/lib/action.js
+++ b/lib/action.js
@@ -33,6 +33,14 @@ function buildAction(browser, page, options, actionString) {
 	};
 }
 
+module.exports.isValidAction = isValidAction;
+
+function isValidAction(actionString) {
+	return module.exports.allowedActions.some(function(allowedAction) {
+		return allowedAction.match.test(actionString);
+	});
+}
+
 module.exports.allowedActions = [
 
 	// Action to click an element

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -11,6 +11,7 @@ var trufflerPkg = require('truffler/package.json');
 var phantomjsPath = require('phantomjs-prebuilt').path;
 
 module.exports = pa11y;
+module.exports.validateAction = buildAction.isValidAction;
 module.exports.defaults = {
 	actions: [],
 	beforeScript: null,

--- a/test/unit/lib/action.js
+++ b/test/unit/lib/action.js
@@ -19,6 +19,10 @@ describe('lib/action', function() {
 		assert.isArray(buildAction.allowedActions);
 	});
 
+	it('has an `isValidAction` method', function() {
+		assert.isFunction(buildAction.isValidAction);
+	});
+
 	describe('buildAction(browser, page, options, actionString)', function() {
 		var browser;
 		var mockActionRunner1;
@@ -167,6 +171,26 @@ describe('lib/action', function() {
 
 			});
 
+		});
+
+	});
+
+	describe('.isValidAction(actionString)', function() {
+
+		beforeEach(function() {
+			buildAction.allowedActions = [
+				{
+					match: /foo/i
+				}
+			];
+		});
+
+		it('should return `true` when the actionString matches one of the allowed actions', function() {
+			assert.isTrue(buildAction.isValidAction('hello foo!'));
+		});
+
+		it('should return `false` when the actionString does not match any of the allowed actions', function() {
+			assert.isFalse(buildAction.isValidAction('hello bar!'));
 		});
 
 	});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -12,6 +12,7 @@ describe('lib/pa11y', function() {
 	beforeEach(function() {
 
 		buildAction = sinon.stub().returns(sinon.stub().yieldsAsync());
+		buildAction.isValidAction = sinon.stub();
 		mockery.registerMock('./action', buildAction);
 
 		extend = sinon.spy(require('node.extend'));
@@ -534,6 +535,11 @@ describe('lib/pa11y', function() {
 				done();
 			});
 		});
+	});
+
+	it('should have a `validateAction` method which aliases actions.isValidAction', function() {
+		assert.isFunction(pa11y.validateAction);
+		assert.strictEqual(pa11y.validateAction, buildAction.isValidAction);
 	});
 
 });


### PR DESCRIPTION
Ideally we want to be able to check whether an action is valid before using it. This is especially useful in Pa11y webservice which would otherwise fail pretty much silently when an invalid action is encountered.

This adds the following method to pa11y:

```js
pa11y.validateAction('click element #submit');  // true
pa11y.validateAction('open the pod bay doors'); // false
```