### PR TITLE
Add negated version of "wait-for-url" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ pa11y({
         'check field #terms-and-conditions',
         'uncheck field #subscribe-to-marketing',
         'wait for fragment to be #page-2',
-        'wait for path to be /login',
+        'wait for path to not be /login',
         'wait for url to be https://example.com/'
     ]
 });
@@ -656,11 +656,14 @@ pa11y({
 
 ### Wait For Fragment/Path/URL
 
-This allows you to pause the test until a condition is met, and the page has either a given fragment, path, or URL. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. This action takes one of the forms:
+This allows you to pause the test until a condition is met, and the page has either a given fragment, path, or URL. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. You can also wait until the page does **not** have a given fragment, path, or URL using the `to not be` syntax. This action takes one of the forms:
 
-  - `wait for fragment to be <fragment>` (including the preceeding `#`)
-  - `wait for path to be <path>` (including the preceeding `/`)
+  - `wait for fragment to be <fragment>` (including the preceding `#`)
+  - `wait for fragment to not be <fragment>` (including the preceding `#`)
+  - `wait for path to be <path>` (including the preceding `/`)
+  - `wait for path to not be <path>` (including the preceding `/`)
   - `wait for url to be <url>`
+  - `wait for url to not be <url>`
 
 E.g.
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -136,10 +136,11 @@ module.exports.allowedActions = [
 	// E.g. "wait for url to be https://example.com/"
 	{
 		name: 'wait-for-url',
-		match: /^wait for (fragment|hash|path|url)( to be)? (.+)$/i,
+		match: /^wait for (fragment|hash|path|url)( to (not )?be)? (.+)$/i,
 		build: function(browser, page, options, matches) {
 			var actionOptions = {
-				expectedValue: matches[3],
+				expectedValue: matches[4],
+				negated: matches[3] !== undefined,
 				subject: matches[1]
 			};
 
@@ -162,7 +163,7 @@ module.exports.allowedActions = [
 					return value;
 				}, actionOptions, function(error, result) {
 					options.log.debug('  … waiting ("' + result + '")');
-					if (result === actionOptions.expectedValue) {
+					if ((result === actionOptions.expectedValue) === !actionOptions.negated) {
 						done();
 					} else {
 						setTimeout(function() {

--- a/test/unit/lib/action.js
+++ b/test/unit/lib/action.js
@@ -738,31 +738,64 @@ describe('lib/action', function() {
 					'wait for fragment #foo',
 					'fragment',
 					undefined,
+					undefined,
 					'#foo'
 				]);
 				assert.deepEqual('wait for fragment to be #foo'.match(action.match), [
 					'wait for fragment to be #foo',
 					'fragment',
 					' to be',
+					undefined,
 					'#foo'
 				]);
 				assert.deepEqual('wait for hash to be #foo'.match(action.match), [
 					'wait for hash to be #foo',
 					'hash',
 					' to be',
+					undefined,
 					'#foo'
 				]);
 				assert.deepEqual('wait for path to be /foo'.match(action.match), [
 					'wait for path to be /foo',
 					'path',
 					' to be',
+					undefined,
 					'/foo'
 				]);
 				assert.deepEqual('wait for url to be https://example.com/'.match(action.match), [
 					'wait for url to be https://example.com/',
 					'url',
 					' to be',
+					undefined,
 					'https://example.com/'
+				]);
+				assert.deepEqual('wait for fragment to not be #bar'.match(action.match), [
+					'wait for fragment to not be #bar',
+					'fragment',
+					' to not be',
+					'not ',
+					'#bar'
+				]);
+				assert.deepEqual('wait for hash to not be #bar'.match(action.match), [
+					'wait for hash to not be #bar',
+					'hash',
+					' to not be',
+					'not ',
+					'#bar'
+				]);
+				assert.deepEqual('wait for path to not be /sso/login'.match(action.match), [
+					'wait for path to not be /sso/login',
+					'path',
+					' to not be',
+					'not ',
+					'/sso/login'
+				]);
+				assert.deepEqual('wait for url to not be https://example.com/login'.match(action.match), [
+					'wait for url to not be https://example.com/login',
+					'url',
+					' to not be',
+					'not ',
+					'https://example.com/login'
 				]);
 			});
 
@@ -805,7 +838,8 @@ describe('lib/action', function() {
 					assert.calledOnce(page.evaluate);
 					assert.isFunction(page.evaluate.firstCall.args[0]);
 					assert.deepEqual(page.evaluate.firstCall.args[1], {
-						expectedValue: matches[3],
+						expectedValue: matches[4],
+						negated: false,
 						subject: matches[1]
 					});
 				});
@@ -886,6 +920,26 @@ describe('lib/action', function() {
 							assert.strictEqual(returnedValue, global.window.location.href);
 						});
 
+					});
+
+				});
+
+				describe('handles negation appropriately', function() {
+
+					beforeEach(function(done) {
+						page.evaluate.reset();
+						matches = 'wait for url to not be https://portal.com/login'.match(action.match);
+						returnedValue = action.build({}, page, options, matches);
+						returnedValue(done);
+					});
+
+					it('checks for inequality if match string contains `to not be`', function() {
+						assert.called(page.evaluate);
+						assert.deepEqual(page.evaluate.firstCall.args[1], {
+							expectedValue: 'https://portal.com/login',
+							negated: true,
+							subject: 'url'
+						});
 					});
 
 				});


### PR DESCRIPTION
This updates the `wait-for-url` action to allow test execution to be paused until the page does **not** match a given fragment, path, or URL if "to not be" is included in the action expression as discussed in [#228](https://github.com/pa11y/pa11y/issues/228#issuecomment-275021330).