### PR TITLE
Remove the old pa11y command

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-
-// This file is left in for backwards compatibility
-// It just aliases pa11y.js in the same folder
-require('./pa11y.js');

--- a/test/integration/helper/describe-cli-call.js
+++ b/test/integration/helper/describe-cli-call.js
@@ -21,7 +21,7 @@ function describeCliCall(urlPath, cliArguments, environment, testFunction) {
 				cliArguments.push('--reporter', 'json');
 			}
 
-			var child = spawn('../../bin/pa11y', cliArguments, {
+			var child = spawn('../../bin/pa11y.js', cliArguments, {
 				cwd: path.resolve(__dirname, '../'),
 				env: environment
 			});


### PR DESCRIPTION
The old `bin/pa11y` file was just an alias for `bin/pa11y.js`, and was
only present for backwards compatibility in case people were referring
to it explicitly.

I think it's been long enough that we can remove this now.