### PR TITLE
Support only Node.js 8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,11 @@ matrix:
   include:
 
     # Run linter once
-    - node_js: '7'
+    - node_js: '8'
       env: LINT=true
 
     # Run tests
-    - node_js: '4'
-    - node_js: '5'
-    - node_js: '6'
-    - node_js: '7'
+    - node_js: '8'
 
 # Restrict builds on branches
 branches:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Table Of Contents
 Requirements
 ------------
 
-Pa11y requires [Node.js][node] 4+ to run.
+Pa11y requires [Node.js][node] 8+ to run. If you need support for older versions of Node.js, then please use [Pa11y 4.x][4.x].
 
 ### OS X
 
@@ -668,7 +668,7 @@ pa11y({
     ]
 });
 ```
-You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), including classes and types. 
+You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), including classes and types.
 
 ### Set Field Value
 
@@ -792,7 +792,8 @@ We also maintain a [migration guide](MIGRATION.md) to help you migrate.
 
 | :grey_question: | Major Version | Last Minor Release | Node.js Versions | Support End Date |
 | :-------------- | :------------ | :----------------- | :--------------- | :--------------- |
-| :heart:         | 4             | N/A                | 4+               | N/A              |
+| :heart:         | 5             | N/A                | 8+               | N/A              |
+| :heart:         | 4             | N/A                | 4–8              | N/A              |
 | :skull:         | 3             | 3.8                | 0.12–6           | 2016-12-05       |
 | :skull:         | 2             | 2.4                | 0.10–0.12        | 2016-10-16       |
 | :skull:         | 1             | 1.7                | 0.10             | 2016-06-08       |
@@ -809,8 +810,7 @@ Copyright &copy; 2013–2017, Team Pa11y
 
 
 [1.0-json-reporter]: https://github.com/pa11y/reporter-1.0-json
-[2.x]: https://github.com/pa11y/pa11y/tree/2.x
-[1.x]: https://github.com/pa11y/pa11y/tree/1.x
+[4.x]: https://github.com/pa11y/pa11y/tree/4.x
 [async]: https://github.com/caolan/async
 [brew]: http://mxcl.github.com/homebrew/
 [node]: http://nodejs.org/

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": "https://github.com/pa11y/pa11y/issues",
   "license": "LGPL-3.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "dependencies": {
     "async": "^2.2.0",


### PR DESCRIPTION
This removes support for Node.js < 8, as we'll need to use async and
await for Headless Chrome support. I've linked to a currently
non-existant 4.x branch for anybody who needs support for older
versions, and I imagine we'll be maintaining 4.x for a year or so.