### PR TITLE
Rename "messages" to "issues"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Usage: pa11y [options] <url>
     -n, --environment              output details about the environment Pa11y will run in
     -s, --standard <name>          the accessibility standard to use: Section508, WCAG2A, WCAG2AA (default), WCAG2AAA
     -r, --reporter <reporter>      the reporter to use: cli (default), csv, tsv, html, json
-    -l, --level <level>            the level of message to fail on (exit with code 2): error, warning, notice
+    -l, --level <level>            the level of issue to fail on (exit with code 2): error, warning, notice
     -T, --threshold <number>       permit this number of errors, warnings, or notices, otherwise fail with exit code 2
-    -i, --ignore <ignore>          types and codes of messages to ignore, a repeatable value or separated by semi-colons
+    -i, --ignore <ignore>          types and codes of issues to ignore, a repeatable value or separated by semi-colons
     -R, --root-element <selector>  a CSS selector used to limit which part of a page is tested
     -E, --hide-elements <hide>     a CSS selector to hide elements from testing, selectors can be comma separated
     -c, --config <path>            a JSON or JavaScript config file
@@ -268,7 +268,7 @@ Pa11y resolves with a `results` object, containing details about the page and ac
 ```js
 {
     documentTitle: 'The title of the page that was tested',
-    messages: [
+    issues: [
         {
             code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
             context: '<a href="http://example.com/"><img src="example.jpg" alt=""/></a>',

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -28,7 +28,7 @@ function configureProgram() {
 		)
 		.option(
 			'-l, --level <level>',
-			'the level of message to fail on (exit with code 2): error, warning, notice',
+			'the level of issue to fail on (exit with code 2): error, warning, notice',
 			'error'
 		)
 		.option(
@@ -38,7 +38,7 @@ function configureProgram() {
 		)
 		.option(
 			'-i, --ignore <ignore>',
-			'types and codes of messages to ignore, a repeatable value or separated by semi-colons',
+			'types and codes of issues to ignore, a repeatable value or separated by semi-colons',
 			collectOptions,
 			[]
 		)
@@ -94,12 +94,12 @@ async function runProgram() {
 	options.log.begin(program.url);
 	try {
 		const pa11yReport = await pa11y(program.url, options);
-		if (reportShouldFail(program.level, pa11yReport.messages, program.threshold)) {
+		if (reportShouldFail(program.level, pa11yReport.issues, program.threshold)) {
 			process.once('exit', () => {
 				process.exit(2);
 			});
 		}
-		options.log.results(pa11yReport.messages, program.url);
+		options.log.results(pa11yReport.issues, program.url);
 	} catch (error) {
 		options.log.error(error.stack);
 		process.exit(1);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,10 +8,10 @@
 	/* eslint-enable no-underscore-dangle */
 
 	/**
-	 * A map of message type codes to names.
+	 * A map of issue type codes to names.
 	 * @private
 	 */
-	const messageTypeMap = {
+	const issueTypeMap = {
 		1: 'error',
 		2: 'warning',
 		3: 'notice'
@@ -26,11 +26,11 @@
 	async function runPa11y(options) {
 		await wait(options.wait);
 
-		// Load and process the messages
+		// Load and process the issues
 		configureHtmlCodeSniffer();
 		return {
 			documentTitle: window.document.title || '',
-			messages: processMessages(await runHtmlCodeSniffer())
+			issues: processIssues(await runHtmlCodeSniffer())
 		};
 
 		/**
@@ -65,7 +65,7 @@
 		/**
 		 * Run HTML CodeSniffer on the current page.
 		 * @private
-		 * @returns {Promise} Returns a promise which resolves with HTML CodeSniffer messages.
+		 * @returns {Promise} Returns a promise which resolves with HTML CodeSniffer issues.
 		 */
 		function runHtmlCodeSniffer() {
 			return new Promise((resolve, reject) => {
@@ -79,35 +79,35 @@
 		}
 
 		/**
-		 * Process HTML CodeSniffer messages.
+		 * Process HTML CodeSniffer issues.
 		 * @private
-		 * @param {Array} messages - An array of HTML CodeSniffer messages to process.
-		 * @returns {Array} Returns an array of processed messages.
+		 * @param {Array} issues - An array of HTML CodeSniffer issues to process.
+		 * @returns {Array} Returns an array of processed issues.
 		 */
-		function processMessages(messages) {
+		function processIssues(issues) {
 			if (options.rootElement) {
-				messages = messages.filter(isMessageInTestArea);
+				issues = issues.filter(isIssueInTestArea);
 			}
 			if (options.hideElements) {
-				messages = messages.filter(isElementOutsideHiddenArea);
+				issues = issues.filter(isElementOutsideHiddenArea);
 			}
-			return messages.map(processMessage).filter(isMessageNotIgnored);
+			return issues.map(processIssue).filter(isIssueNotIgnored);
 		}
 
 		/**
-		 * Process a HTML CodeSniffer message.
+		 * Process a HTML CodeSniffer issue.
 		 * @private
-		 * @param {Object} message - An HTML CodeSniffer message to process.
-		 * @returns {Object} Returns the processed message.
+		 * @param {Object} issue - An HTML CodeSniffer issue to process.
+		 * @returns {Object} Returns the processed issue.
 		 */
-		function processMessage(message) {
+		function processIssue(issue) {
 			return {
-				code: message.code,
-				context: processMessageHtml(message.element),
-				message: message.msg,
-				type: messageTypeMap[message.type] || 'unknown',
-				typeCode: message.type,
-				selector: getCssSelectorForElement(message.element)
+				code: issue.code,
+				context: processIssueHtml(issue.element),
+				message: issue.msg,
+				type: issueTypeMap[issue.type] || 'unknown',
+				typeCode: issue.type,
+				selector: getCssSelectorForElement(issue.element)
 			};
 		}
 
@@ -117,7 +117,7 @@
 		 * @param {HTMLElement} element - An element to get short HTML for.
 		 * @returns {String} Returns the short HTML as a string.
 		 */
-		function processMessageHtml(element) {
+		function processIssueHtml(element) {
 			let outerHTML = null;
 			let innerHTML = null;
 			if (!element.outerHTML) {
@@ -209,42 +209,42 @@
 		}
 
 		/**
-		 * Check whether a message should be returned, and is not ignored.
+		 * Check whether an issue should be returned, and is not ignored.
 		 * @private
-		 * @param {Object} message - The message to check.
-		 * @returns {Boolean} Returns whether the message should be returned.
+		 * @param {Object} issue - The issue to check.
+		 * @returns {Boolean} Returns whether the issue should be returned.
 		 */
-		function isMessageNotIgnored(message) {
-			if (options.ignore.indexOf(message.code.toLowerCase()) !== -1) {
+		function isIssueNotIgnored(issue) {
+			if (options.ignore.indexOf(issue.code.toLowerCase()) !== -1) {
 				return false;
 			}
-			if (options.ignore.indexOf(message.type) !== -1) {
+			if (options.ignore.indexOf(issue.type) !== -1) {
 				return false;
 			}
 			return true;
 		}
 
 		/**
-		 * Check whether a message is in the test area specified by rootElement.
+		 * Check whether an issue is in the test area specified by rootElement.
 		 * @private
-		 * @param {Object} message - The message to check.
-		 * @returns {Boolean} Returns whether the messages is in the test area.
+		 * @param {Object} issue - The issue to check.
+		 * @returns {Boolean} Returns whether the issue is in the test area.
 		 */
-		function isMessageInTestArea(message) {
+		function isIssueInTestArea(issue) {
 			const rootElement = window.document.querySelector(options.rootElement);
-			return (rootElement ? rootElement.contains(message.element) : true);
+			return (rootElement ? rootElement.contains(issue.element) : true);
 		}
 
 		/**
 		 * Check whether an element is outside of all hidden selectors.
 		 * @private
-		 * @param {Object} message - The message to check.
-		 * @returns {Boolean} Returns whether the message is outside of a hidden area.
+		 * @param {Object} issue - The issue to check.
+		 * @returns {Boolean} Returns whether the issue is outside of a hidden area.
 		 */
-		function isElementOutsideHiddenArea(message) {
+		function isElementOutsideHiddenArea(issue) {
 			const hiddenElements = [...window.document.querySelectorAll(options.hideElements)];
 			return !hiddenElements.some(hiddenElement => {
-				return hiddenElement.contains(message.element);
+				return hiddenElement.contains(issue.element);
 			});
 		}
 

--- a/test/unit/lib/runner.js
+++ b/test/unit/lib/runner.js
@@ -36,7 +36,7 @@ describe('lib/runner', () => {
 					element: createMockElement({
 						id: 'mock-element'
 					}),
-					msg: 'mock message',
+					msg: 'mock issue',
 					type: 1
 				}
 			]);
@@ -60,20 +60,20 @@ describe('lib/runner', () => {
 			assert.isFunction(global.window.HTMLCS.process.firstCall.args[2]);
 		});
 
-		it('gets HTML CodeSniffer messages', () => {
+		it('gets HTML CodeSniffer issues', () => {
 			assert.calledOnce(global.window.HTMLCS.getMessages);
 			assert.calledWithExactly(global.window.HTMLCS.getMessages);
 		});
 
-		it('resolves with page details and an array of processed HTML CodeSniffer messages', () => {
+		it('resolves with page details and an array of processed HTML CodeSniffer issues', () => {
 			assert.isObject(resolvedValue);
 			assert.strictEqual(resolvedValue.documentTitle, window.document.title);
-			assert.isArray(resolvedValue.messages);
-			assert.deepEqual(resolvedValue.messages, [
+			assert.isArray(resolvedValue.issues);
+			assert.deepEqual(resolvedValue.issues, [
 				{
 					code: 'mock-code',
 					context: '<element>mock-html</element>',
-					message: 'mock message',
+					message: 'mock issue',
 					selector: '#mock-element',
 					type: 'error',
 					typeCode: 1
@@ -95,7 +95,7 @@ describe('lib/runner', () => {
 
 		});
 
-		describe('when a message type code is not found', () => {
+		describe('when an issue type code is not found', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -104,7 +104,7 @@ describe('lib/runner', () => {
 						element: createMockElement({
 							id: 'mock-element'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 7
 					}
 				]);
@@ -112,12 +112,12 @@ describe('lib/runner', () => {
 			});
 
 			it('resolves with a `type` of "unknown"', () => {
-				assert.strictEqual(resolvedValue.messages[0].type, 'unknown');
+				assert.strictEqual(resolvedValue.issues[0].type, 'unknown');
 			});
 
 		});
 
-		describe('when a message element has no `outerHTML`', () => {
+		describe('when an issue element has no `outerHTML`', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -127,7 +127,7 @@ describe('lib/runner', () => {
 							id: 'mock-element',
 							outerHTML: ''
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -135,12 +135,12 @@ describe('lib/runner', () => {
 			});
 
 			it('resolves with a `context` of `null`', () => {
-				assert.isNull(resolvedValue.messages[0].context);
+				assert.isNull(resolvedValue.issues[0].context);
 			});
 
 		});
 
-		describe('when a message element has a long `innerHTML`', () => {
+		describe('when an issue element has a long `innerHTML`', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -151,7 +151,7 @@ describe('lib/runner', () => {
 							innerHTML: 'mock-html-that-is-longer-than-31-characters',
 							outerHTML: '<element>mock-html-that-is-longer-than-31-characters</element>'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -159,12 +159,12 @@ describe('lib/runner', () => {
 			});
 
 			it('resolves with a `context` that has truncated `innerHTML`', () => {
-				assert.strictEqual(resolvedValue.messages[0].context, '<element>mock-html-that-is-longer-than-3...</element>');
+				assert.strictEqual(resolvedValue.issues[0].context, '<element>mock-html-that-is-longer-than-3...</element>');
 			});
 
 		});
 
-		describe('when a message element has a long `outerHTML`', () => {
+		describe('when an issue element has a long `outerHTML`', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -174,7 +174,7 @@ describe('lib/runner', () => {
 							id: 'mock-element',
 							outerHTML: '<element alphabetx10="abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz">mock-html</element>'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -182,12 +182,12 @@ describe('lib/runner', () => {
 			});
 
 			it('resolves with a `context` that has truncated `innerHTML`', () => {
-				assert.strictEqual(resolvedValue.messages[0].context, '<element alphabetx10="abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst...');
+				assert.strictEqual(resolvedValue.issues[0].context, '<element alphabetx10="abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst...');
 			});
 
 		});
 
-		describe('when a message element does not have an ID', () => {
+		describe('when an issue element does not have an ID', () => {
 
 			describe('but it\'s parent node does have an ID', () => {
 
@@ -204,7 +204,7 @@ describe('lib/runner', () => {
 						{
 							code: 'mock-code',
 							element: child,
-							msg: 'mock message',
+							msg: 'mock issue',
 							type: 1
 						}
 					]);
@@ -212,7 +212,7 @@ describe('lib/runner', () => {
 				});
 
 				it('resolves with a `selector` that includes the parent ID and child tagname', () => {
-					assert.strictEqual(resolvedValue.messages[0].selector, '#mock-parent > child');
+					assert.strictEqual(resolvedValue.issues[0].selector, '#mock-parent > child');
 				});
 
 			});
@@ -231,7 +231,7 @@ describe('lib/runner', () => {
 						{
 							code: 'mock-code',
 							element: child,
-							msg: 'mock message',
+							msg: 'mock issue',
 							type: 1
 						}
 					]);
@@ -239,7 +239,7 @@ describe('lib/runner', () => {
 				});
 
 				it('resolves with a `selector` that includes the parent and child tagnames', () => {
-					assert.strictEqual(resolvedValue.messages[0].selector, 'parent > child');
+					assert.strictEqual(resolvedValue.issues[0].selector, 'parent > child');
 				});
 
 			});
@@ -268,7 +268,7 @@ describe('lib/runner', () => {
 						{
 							code: 'mock-code',
 							element: child,
-							msg: 'mock message',
+							msg: 'mock issue',
 							type: 1
 						}
 					]);
@@ -276,7 +276,7 @@ describe('lib/runner', () => {
 				});
 
 				it('resolves with a `selector` that includes an `nth-child` pseudo-class', () => {
-					assert.strictEqual(resolvedValue.messages[0].selector, 'parent > child:nth-child(2)');
+					assert.strictEqual(resolvedValue.issues[0].selector, 'parent > child:nth-child(2)');
 				});
 
 			});
@@ -292,7 +292,7 @@ describe('lib/runner', () => {
 						{
 							code: 'mock-code',
 							element: child,
-							msg: 'mock message',
+							msg: 'mock issue',
 							type: 1
 						}
 					]);
@@ -300,7 +300,7 @@ describe('lib/runner', () => {
 				});
 
 				it('resolves with an empty `selector`', () => {
-					assert.strictEqual(resolvedValue.messages[0].selector, '');
+					assert.strictEqual(resolvedValue.issues[0].selector, '');
 				});
 
 			});
@@ -327,7 +327,7 @@ describe('lib/runner', () => {
 
 		});
 
-		describe('when `options.ignore` includes a message type', () => {
+		describe('when `options.ignore` includes an issue type', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -336,7 +336,7 @@ describe('lib/runner', () => {
 						element: createMockElement({
 							id: 'mock-element'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					},
 					{
@@ -344,7 +344,7 @@ describe('lib/runner', () => {
 						element: createMockElement({
 							id: 'mock-element'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 2
 					}
 				]);
@@ -354,12 +354,12 @@ describe('lib/runner', () => {
 				resolvedValue = await runPa11y(options);
 			});
 
-			it('does not resolve with messages of that type', () => {
-				assert.deepEqual(resolvedValue.messages, [
+			it('does not resolve with issues of that type', () => {
+				assert.deepEqual(resolvedValue.issues, [
 					{
 						code: 'mock-warning',
 						context: '<element>mock-html</element>',
-						message: 'mock message',
+						message: 'mock issue',
 						selector: '#mock-element',
 						type: 'warning',
 						typeCode: 2
@@ -369,7 +369,7 @@ describe('lib/runner', () => {
 
 		});
 
-		describe('when `options.ignore` includes a message code', () => {
+		describe('when `options.ignore` includes an issue code', () => {
 
 			beforeEach(async () => {
 				global.window.HTMLCS.getMessages.returns([
@@ -378,7 +378,7 @@ describe('lib/runner', () => {
 						element: createMockElement({
 							id: 'mock-element'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					},
 					{
@@ -386,7 +386,7 @@ describe('lib/runner', () => {
 						element: createMockElement({
 							id: 'mock-element'
 						}),
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -396,12 +396,12 @@ describe('lib/runner', () => {
 				resolvedValue = await runPa11y(options);
 			});
 
-			it('does not resolve with messages with that code', () => {
-				assert.deepEqual(resolvedValue.messages, [
+			it('does not resolve with issues with that code', () => {
+				assert.deepEqual(resolvedValue.issues, [
 					{
 						code: 'mock-code-2',
 						context: '<element>mock-html</element>',
-						message: 'mock message',
+						message: 'mock issue',
 						selector: '#mock-element',
 						type: 'error',
 						typeCode: 1
@@ -409,7 +409,7 @@ describe('lib/runner', () => {
 				]);
 			});
 
-			describe('when the message code case does not match', () => {
+			describe('when the issue code case does not match', () => {
 
 				beforeEach(async () => {
 					global.window.HTMLCS.getMessages.returns([
@@ -418,7 +418,7 @@ describe('lib/runner', () => {
 							element: createMockElement({
 								id: 'mock-element'
 							}),
-							msg: 'mock message',
+							msg: 'mock issue',
 							type: 1
 						}
 					]);
@@ -428,8 +428,8 @@ describe('lib/runner', () => {
 					resolvedValue = await runPa11y(options);
 				});
 
-				it('still does not resolve with messages with that code', () => {
-					assert.deepEqual(resolvedValue.messages, []);
+				it('still does not resolve with issues with that code', () => {
+					assert.deepEqual(resolvedValue.issues, []);
 				});
 
 			});
@@ -461,13 +461,13 @@ describe('lib/runner', () => {
 					{
 						code: 'mock-code-1',
 						element: insideElement,
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					},
 					{
 						code: 'mock-code-2',
 						element: outsideElement,
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -479,12 +479,12 @@ describe('lib/runner', () => {
 				assert.calledWithExactly(window.document.querySelector, '#root-element');
 			});
 
-			it('does not resolve with messages outside of the root element', () => {
-				assert.deepEqual(resolvedValue.messages, [
+			it('does not resolve with issues outside of the root element', () => {
+				assert.deepEqual(resolvedValue.issues, [
 					{
 						code: 'mock-code-1',
 						context: '<element>mock-html</element>',
-						message: 'mock message',
+						message: 'mock issue',
 						selector: '#mock-inside-element',
 						type: 'error',
 						typeCode: 1
@@ -499,12 +499,12 @@ describe('lib/runner', () => {
 					resolvedValue = await runPa11y(options);
 				});
 
-				it('resolves with all messages', () => {
-					assert.deepEqual(resolvedValue.messages, [
+				it('resolves with all issues', () => {
+					assert.deepEqual(resolvedValue.issues, [
 						{
 							code: 'mock-code-1',
 							context: '<element>mock-html</element>',
-							message: 'mock message',
+							message: 'mock issue',
 							selector: '#mock-inside-element',
 							type: 'error',
 							typeCode: 1
@@ -512,7 +512,7 @@ describe('lib/runner', () => {
 						{
 							code: 'mock-code-2',
 							context: '<element>mock-html</element>',
-							message: 'mock message',
+							message: 'mock issue',
 							selector: '#mock-outside-element',
 							type: 'error',
 							typeCode: 1
@@ -551,19 +551,19 @@ describe('lib/runner', () => {
 					{
 						code: 'mock-code-1',
 						element: unhiddenElement,
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					},
 					{
 						code: 'mock-code-2',
 						element: hiddenElement,
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					},
 					{
 						code: 'mock-code-3',
 						element: childOfHiddenElement,
-						msg: 'mock message',
+						msg: 'mock issue',
 						type: 1
 					}
 				]);
@@ -575,12 +575,12 @@ describe('lib/runner', () => {
 				assert.calledWithExactly(window.document.querySelectorAll, options.hideElements);
 			});
 
-			it('does not resolve with messages inside hidden elements, or that are hidden themselves', () => {
-				assert.deepEqual(resolvedValue.messages, [
+			it('does not resolve with issues inside hidden elements, or that are hidden themselves', () => {
+				assert.deepEqual(resolvedValue.issues, [
 					{
 						code: 'mock-code-1',
 						context: '<element>mock-html</element>',
-						message: 'mock message',
+						message: 'mock issue',
 						selector: '#mock-unhidden-element',
 						type: 'error',
 						typeCode: 1


### PR DESCRIPTION
This was bugging me, as we have a situation where we'd have to refer to
`message.message`. We're now referring to the things that HTML
CodeSniffer sends back as "issues". I think it's more descriptive too.