### PR TITLE
Support callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ Pa11y can also be run with [some options](#configuration):
 ```js
 pa11y('http://example.com/', {
     // Options go here
-})
+}).then((results) => {
+    // Do something with the results
+});
 ```
 
 Pa11y resolves with a `results` object, containing details about the page and accessibility issues from HTML CodeSniffer. It looks like this:
@@ -297,6 +299,8 @@ Pa11y resolves with a `results` object, containing details about the page and ac
 }
 ```
 
+### Transforming the Results
+
 If you wish to transform these results with the command-line reporters, then you can do so in your code by requiring them in. The `csv`, `tsv`, `html`, `json`, and `markdown` reporters all expose a `process` method:
 
 ```js
@@ -304,6 +308,33 @@ If you wish to transform these results with the command-line reporters, then you
 // are available in a `results` variable:
 const htmlReporter = require('pa11y/reporter/html');
 const html = htmlReporter.process(results, url);
+```
+
+### Async/Await
+
+Because Pa11y is promise based, you can use `async` functions and the `await` keyword:
+
+```js
+async function runPa11y() {
+    try {
+        const results = await pa11y('http://example.com/');
+        // Do something with the results
+    } catch (error) {
+        // Handle the error
+    }
+}
+
+runPa11y();
+```
+
+### Callback Interface
+
+If you would rather use callbacks than promises or `async`/`await`, then Pa11y supports this. This interface should be considered legacy, however, and may not appear in the next major version of Pa11y:
+
+```js
+pa11y('http://example.com/', (error, results) => {
+    // Do something with the results or handle the error
+});
 ```
 
 ### Validating Actions

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -14,10 +14,21 @@ module.exports = pa11y;
  * @public
  * @param {String} [url] - The URL to run tests against.
  * @param {Object} [options={}] - Options to change the way tests run.
+ * @param {Function} [callback] - An optional callback to use instead of promises.
  * @returns {Promise} Returns a promise which resolves with a results object.
  */
-async function pa11y(url, options = {}) {
+async function pa11y(url, options = {}, callback) {
 	const state = {};
+
+	/* eslint-disable prefer-rest-params */
+	// Check for presence of a callback function
+	if (typeof arguments[arguments.length - 1] === 'function') {
+		callback = arguments[arguments.length - 1];
+	} else {
+		callback = undefined;
+	}
+	/* eslint-enable prefer-rest-params */
+
 	try {
 
 		// Switch parameters if only an options object is provided,
@@ -34,15 +45,26 @@ async function pa11y(url, options = {}) {
 
 		// Call the actual Pa11y test runner with
 		// a timeout if it takes too long
-		return await promiseTimeout(
+		const results = await promiseTimeout(
 			runPa11yTest(url, options, state),
 			options.timeout,
 			`Pa11y timed out (${options.timeout}ms)`
 		);
 
+		// Run callback if present, and resolve with results
+		if (callback) {
+			return callback(null, results);
+		}
+		return results;
+
 	} catch (error) {
 		if (state.browser) {
 			state.browser.close();
+		}
+
+		// Run callback if present, and reject with error
+		if (callback) {
+			return callback(error);
 		}
 		throw error;
 	}

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -419,6 +419,49 @@ describe('lib/pa11y', () => {
 
 	});
 
+	describe('pa11y(url, callback)', () => {
+		let callbackError;
+		let callbackResults;
+
+		beforeEach(done => {
+			pa11y('https://mock-url/', (error, results) => {
+				callbackError = error;
+				callbackResults = results;
+				done();
+			});
+		});
+
+		it('calls back with the Pa11y results', () => {
+			assert.strictEqual(callbackResults, pa11yResults);
+		});
+
+		describe('when something errors', () => {
+			let headlessChromeError;
+
+			beforeEach(done => {
+				headlessChromeError = new Error('headless chrome error');
+				puppeteer.mockBrowser.close.reset();
+				puppeteer.mockPage.goto.rejects(headlessChromeError);
+				pa11y('https://mock-url/', (error, results) => {
+					callbackError = error;
+					callbackResults = results;
+					done();
+				});
+			});
+
+			it('closes the browser', () => {
+				assert.calledOnce(puppeteer.mockBrowser.close);
+				assert.calledWithExactly(puppeteer.mockBrowser.close);
+			});
+
+			it('calls back with the error', () => {
+				assert.strictEqual(callbackError, headlessChromeError);
+			});
+
+		});
+
+	});
+
 	it('has an `isValidAction` method which aliases `action.isValidAction`', () => {
 		assert.isFunction(pa11y.isValidAction);
 		assert.strictEqual(pa11y.isValidAction, runAction.isValidAction);


### PR DESCRIPTION
This updates the `pa11y` function to support callbacks if an end user
prefers to use these over promises.

This resolves #305