### PR TITLE
Ignore warnings and notices by default

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -27,6 +27,10 @@ Pa11y 5.0 switches from PhantomJS to [Headless Chrome](https://developers.google
 
 Pa11y 5.0 only supports Node.js v8.0.0 and higher, you'll need to upgrade to be able to use the latest versions of Pa11y.
 
+### Warnings and Notices
+
+Pa11y 5.0 ignores warnings and notices by default, as these are not usually actionable or useful in automated testing. You can force Pa11y to include warnings and notices again by using the `--include-non-errors` command-line flag or the `includeNonErrors` option.
+
 ### Command-Line Interface
 
 The command-line interface in 5.0 is similar to 4.0, but there are a few key changes.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,7 +29,9 @@ Pa11y 5.0 only supports Node.js v8.0.0 and higher, you'll need to upgrade to be 
 
 ### Warnings and Notices
 
-Pa11y 5.0 ignores warnings and notices by default, as these are not usually actionable or useful in automated testing. You can force Pa11y to include warnings and notices again by using the `--include-non-errors` command-line flag or the `includeNonErrors` option.
+Pa11y 5.0 ignores warnings and notices by default, as these are not usually actionable or useful in automated testing.
+
+You can force Pa11y to include warnings and notices again by using the `--include-notices` and `--include-warnings` command-line flags, or the `includeNotices` and `includeWarnings` options.
 
 ### Command-Line Interface
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Usage: pa11y [options] <url>
     -l, --level <level>            the level of issue to fail on (exit with code 2): error, warning, notice
     -T, --threshold <number>       permit this number of errors, warnings, or notices, otherwise fail with exit code 2
     -i, --ignore <ignore>          types and codes of issues to ignore, a repeatable value or separated by semi-colons
-    --include-non-errors           Include warnings and notices in the report
+    --include-notices              Include notices in the report
+    --include-warnings             Include warnings in the report
     -R, --root-element <selector>  a CSS selector used to limit which part of a page is tested
     -E, --hide-elements <hide>     a CSS selector to hide elements from testing, selectors can be comma separated
     -c, --config <path>            a JSON or JavaScript config file
@@ -421,24 +422,25 @@ pa11y('http://example.com/', {
 
 Defaults to an empty array.
 
-### `includeNonErrors` (boolean)
+### `includeNotices` (boolean)
 
-Whether to include non-error results in the Pa11y report. Issues with a type of `warning` or `notice` are not directly actionable and so they are excluded by default. You can include them by using this option:
+Whether to include results with a type of `notice` in the Pa11y report. Issues with a type of `notice` are not directly actionable and so they are excluded by default. You can include them by using this option:
 
 ```js
 pa11y('http://example.com/', {
-    includeNonErrors: true
+    includeNotices: true
 });
 ```
 
-You can use this in combination with the `ignore` flag if you want to, for example, show only errors and warnings but ignore notices:
+Defaults to `false`.
+
+### `includeWarnings` (boolean)
+
+Whether to include results with a type of `warning` in the Pa11y report. Issues with a type of `warning` are not directly actionable and so they are excluded by default. You can include them by using this option:
 
 ```js
 pa11y('http://example.com/', {
-    includeNonErrors: true,
-    ignore: [
-        'notice'
-    ]
+    includeWarnings: true
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Usage: pa11y [options] <url>
     -l, --level <level>            the level of issue to fail on (exit with code 2): error, warning, notice
     -T, --threshold <number>       permit this number of errors, warnings, or notices, otherwise fail with exit code 2
     -i, --ignore <ignore>          types and codes of issues to ignore, a repeatable value or separated by semi-colons
+    --include-non-errors           Include warnings and notices in the report
     -R, --root-element <selector>  a CSS selector used to limit which part of a page is tested
     -E, --hide-elements <hide>     a CSS selector to hide elements from testing, selectors can be comma separated
     -c, --config <path>            a JSON or JavaScript config file
@@ -171,13 +172,13 @@ For more information on configuring Pa11y, see the [configuration documentation]
 The ignore flag can be used in several different ways. Separated by semi-colons:
 
 ```
-pa11y --ignore "warning;notice" http://example.com
+pa11y --ignore "issue-code-1;issue-code-2" http://example.com
 ```
 
 or by using the flag multiple times:
 
 ```
-pa11y --ignore warning --ignore notice http://example.com
+pa11y --ignore issue-code-1 --ignore issue-code-2 http://example.com
 ```
 
 Pa11y can also ignore notices, warnings, and errors up to a threshold number. This might be useful if you're using CI and don't want to break your build. The following example will return exit code 0 on a page with 9 errors, and return exit code 2 on a page with 10 or more errors.
@@ -279,23 +280,8 @@ Pa11y resolves with a `results` object, containing details about the page and ac
             selector: 'html > body > p:nth-child(1) > a',
             type: 'error',
             typeCode: 1
-        },
-        {
-            code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
-            context: '<b>Hello World!</b>',
-            message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
-            selector: '#content > b:nth-child(4)',
-            type: 'warning',
-            typeCode: 2
-        },
-        {
-            code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
-            context: '<a href="http://example.com/">Hello World!</a>',
-            message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
-            selector: 'html > body > ul > li:nth-child(2) > a',
-            type: 'notice',
-            typeCode: 3
         }
+        // more issues appear here
     ]
 }
 ```
@@ -423,18 +409,29 @@ pa11y('http://example.com/', {
 
 ### `ignore` (array)
 
-An array of result codes and types that you'd like to ignore. You can find the codes for each rule in the console output and the types are `error`, `warning`, and `notice`.
+An array of result codes and types that you'd like to ignore. You can find the codes for each rule in the console output and the types are `error`, `warning`, and `notice`. Note: `warning` and `notice` messages are ignored by default.
 
 ```js
 pa11y('http://example.com/', {
     ignore: [
-        'notice',
         'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2'
     ]
 });
 ```
 
 Defaults to an empty array.
+
+### `includeNonErrors` (boolean)
+
+Whether to include non-error results in the Pa11y report. Issues with a type of `warning` or `notice` are not directly actionable and so they are excluded by default. You can include them by using this option:
+
+```js
+pa11y('http://example.com/', {
+    includeNonErrors: true
+});
+```
+
+Defaults to `false`.
 
 ### `log` (object)
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,17 @@ pa11y('http://example.com/', {
 });
 ```
 
+You can use this in combination with the `ignore` flag if you want to, for example, show only errors and warnings but ignore notices:
+
+```js
+pa11y('http://example.com/', {
+    includeNonErrors: true,
+    ignore: [
+        'notice'
+    ]
+});
+```
+
 Defaults to `false`.
 
 ### `log` (object)

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -45,6 +45,10 @@ function configureProgram() {
 			[]
 		)
 		.option(
+			'--include-non-errors',
+			'Include warnings and notices in the report'
+		)
+		.option(
 			'-R, --root-element <selector>',
 			'a CSS selector used to limit which part of a page is tested'
 		)
@@ -113,6 +117,7 @@ function processOptions(log) {
 	const options = extend({}, loadConfig(program.config), {
 		hideElements: program.hideElements,
 		ignore: (program.ignore.length ? program.ignore : undefined),
+		includeNonErrors: program.includeNonErrors,
 		rootElement: program.rootElement,
 		rules: (program.addRule.length ? program.addRule : undefined),
 		screenCapture: program.screenCapture,

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -45,8 +45,12 @@ function configureProgram() {
 			[]
 		)
 		.option(
-			'--include-non-errors',
-			'Include warnings and notices in the report'
+			'--include-notices',
+			'Include notices in the report'
+		)
+		.option(
+			'--include-warnings',
+			'Include warnings in the report'
 		)
 		.option(
 			'-R, --root-element <selector>',
@@ -117,7 +121,8 @@ function processOptions(log) {
 	const options = extend({}, loadConfig(program.config), {
 		hideElements: program.hideElements,
 		ignore: (program.ignore.length ? program.ignore : undefined),
-		includeNonErrors: program.includeNonErrors,
+		includeNotices: program.includeNotices,
+		includeWarnings: program.includeWarnings,
 		rootElement: program.rootElement,
 		rules: (program.addRule.length ? program.addRule : undefined),
 		screenCapture: program.screenCapture,

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -169,8 +169,10 @@ async function runPa11yTest(url, options, state) {
 function defaultOptions(options) {
 	options = extend({}, pa11y.defaults, options);
 	options.ignore = options.ignore.map(ignored => ignored.toLowerCase());
-	if (!options.includeNonErrors) {
+	if (!options.includeNotices) {
 		options.ignore.push('notice');
+	}
+	if (!options.includeWarnings) {
 		options.ignore.push('warning');
 	}
 	return options;
@@ -227,7 +229,8 @@ pa11y.defaults = {
 	headers: {},
 	hideElements: null,
 	ignore: [],
-	includeNonErrors: false,
+	includeNotices: false,
+	includeWarnings: false,
 	log: {
 		debug: noop,
 		error: noop,

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -169,6 +169,10 @@ async function runPa11yTest(url, options, state) {
 function defaultOptions(options) {
 	options = extend({}, pa11y.defaults, options);
 	options.ignore = options.ignore.map(ignored => ignored.toLowerCase());
+	if (!options.includeNonErrors) {
+		options.ignore.push('notice');
+		options.ignore.push('warning');
+	}
 	return options;
 }
 
@@ -223,6 +227,7 @@ pa11y.defaults = {
 	headers: {},
 	hideElements: null,
 	ignore: [],
+	includeNonErrors: false,
 	log: {
 		debug: noop,
 		error: noop,

--- a/test/integration/cli/actions-check-field.js
+++ b/test/integration/cli/actions-check-field.js
@@ -15,8 +15,7 @@ describe('CLI action "check-field"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-check-field`, {
 				arguments: [
 					'--config', './mock/config/actions-check-field-on.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});
@@ -37,8 +36,7 @@ describe('CLI action "check-field"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-check-field`, {
 				arguments: [
 					'--config', './mock/config/actions-check-field-off.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/actions-click-element.js
+++ b/test/integration/cli/actions-click-element.js
@@ -15,8 +15,7 @@ describe('CLI action "click-element"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-click-element`, {
 				arguments: [
 					'--config', './mock/config/actions-click-element.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/actions-set-field-value.js
+++ b/test/integration/cli/actions-set-field-value.js
@@ -15,8 +15,7 @@ describe('CLI action "set-field-value"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-set-field-value`, {
 				arguments: [
 					'--config', './mock/config/actions-set-field-value.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/actions-wait-for-element-state.js
+++ b/test/integration/cli/actions-wait-for-element-state.js
@@ -15,8 +15,7 @@ describe('CLI action "wait-for-element-state"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-element-state-added`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-element-state-added.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});
@@ -38,8 +37,7 @@ describe('CLI action "wait-for-element-state"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-element-state-removed`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-element-state-removed.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});
@@ -61,8 +59,7 @@ describe('CLI action "wait-for-element-state"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-element-state-visible`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-element-state-visible.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});
@@ -84,8 +81,7 @@ describe('CLI action "wait-for-element-state"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-element-state-hidden`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-element-state-hidden.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/actions-wait-for-url.js
+++ b/test/integration/cli/actions-wait-for-url.js
@@ -15,8 +15,7 @@ describe('CLI action "wait-for-url"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-url-hash`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-url-hash.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});
@@ -38,8 +37,7 @@ describe('CLI action "wait-for-url"', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/actions-wait-for-url-path`, {
 				arguments: [
 					'--config', './mock/config/actions-wait-for-url-path.json',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/add-rule.js
+++ b/test/integration/cli/add-rule.js
@@ -15,8 +15,7 @@ describe('CLI add-rule', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/contrast`, {
 				arguments: [
 					'--add-rule', 'Principle1.Guideline1_4.1_4_6',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/config.js
+++ b/test/integration/cli/config.js
@@ -15,7 +15,8 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/headers`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--config', './mock/config/headers.json',
 					'--reporter', 'json'
 				]
@@ -37,7 +38,8 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/warnings`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--config', './mock/config/ignore-warnings.json',
 					'--reporter', 'json'
 				]
@@ -56,7 +58,8 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--reporter', 'json'
 				],
 				workingDirectory: path.resolve(`${__dirname}/../mock/config`)

--- a/test/integration/cli/config.js
+++ b/test/integration/cli/config.js
@@ -15,6 +15,7 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/headers`, {
 				arguments: [
+					'--include-non-errors',
 					'--config', './mock/config/headers.json',
 					'--reporter', 'json'
 				]
@@ -36,6 +37,7 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/warnings`, {
 				arguments: [
+					'--include-non-errors',
 					'--config', './mock/config/ignore-warnings.json',
 					'--reporter', 'json'
 				]
@@ -54,6 +56,7 @@ describe('CLI config', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--reporter', 'json'
 				],
 				workingDirectory: path.resolve(`${__dirname}/../mock/config`)

--- a/test/integration/cli/exit-codes.js
+++ b/test/integration/cli/exit-codes.js
@@ -49,7 +49,8 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
-						'--include-non-errors',
+						'--include-notices',
+						'--include-warnings',
 						'--level', 'warning'
 					]
 				});
@@ -66,7 +67,8 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/warnings`, {
 					arguments: [
-						'--include-non-errors',
+						'--include-notices',
+						'--include-warnings',
 						'--level', 'warning'
 					]
 				});
@@ -87,7 +89,8 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
-						'--include-non-errors',
+						'--include-notices',
+						'--include-warnings',
 						'--level', 'notice',
 						// We can't build a page that doesn't include notices, so we have
 						// to fake it by ignoring the only one there is
@@ -107,7 +110,8 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
-						'--include-non-errors',
+						'--include-notices',
+						'--include-warnings',
 						'--level', 'notice'
 					]
 				});
@@ -126,7 +130,8 @@ describe('CLI exit codes', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/many-errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--threshold', '5'
 				]
 			});
@@ -143,7 +148,8 @@ describe('CLI exit codes', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/many-errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--threshold', '4'
 				]
 			});

--- a/test/integration/cli/exit-codes.js
+++ b/test/integration/cli/exit-codes.js
@@ -49,6 +49,7 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
+						'--include-non-errors',
 						'--level', 'warning'
 					]
 				});
@@ -65,6 +66,7 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/warnings`, {
 					arguments: [
+						'--include-non-errors',
 						'--level', 'warning'
 					]
 				});
@@ -85,6 +87,7 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
+						'--include-non-errors',
 						'--level', 'notice',
 						// We can't build a page that doesn't include notices, so we have
 						// to fake it by ignoring the only one there is
@@ -104,6 +107,7 @@ describe('CLI exit codes', () => {
 			before(async () => {
 				pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/notices`, {
 					arguments: [
+						'--include-non-errors',
 						'--level', 'notice'
 					]
 				});
@@ -122,6 +126,7 @@ describe('CLI exit codes', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/many-errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--threshold', '5'
 				]
 			});
@@ -138,6 +143,7 @@ describe('CLI exit codes', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/many-errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--threshold', '4'
 				]
 			});

--- a/test/integration/cli/hide-elements.js
+++ b/test/integration/cli/hide-elements.js
@@ -22,7 +22,7 @@ describe('CLI hide-elements', () => {
 
 		it('ignores issues on and inside the hidden elements', () => {
 			assert.isArray(pa11yResponse.json);
-			assert.lengthEquals(pa11yResponse.json, 2);
+			assert.lengthEquals(pa11yResponse.json, 1);
 		});
 
 	});
@@ -32,6 +32,7 @@ describe('CLI hide-elements', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/hide-elements`, {
 				arguments: [
+					'--include-non-errors',
 					'--hide-elements', 'img, p',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/hide-elements.js
+++ b/test/integration/cli/hide-elements.js
@@ -32,7 +32,8 @@ describe('CLI hide-elements', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/hide-elements`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--hide-elements', 'img, p',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/ignore.js
+++ b/test/integration/cli/ignore.js
@@ -14,6 +14,7 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--ignore', 'warning',
 					'--reporter', 'json'
 				]
@@ -35,6 +36,7 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--ignore', 'warning;notice',
 					'--reporter', 'json'
 				]
@@ -57,6 +59,7 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--ignore', 'warning',
 					'--ignore', 'notice',
 					'--reporter', 'json'
@@ -80,6 +83,7 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--ignore', 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/ignore.js
+++ b/test/integration/cli/ignore.js
@@ -14,7 +14,8 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--ignore', 'warning',
 					'--reporter', 'json'
 				]
@@ -36,7 +37,8 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--ignore', 'warning;notice',
 					'--reporter', 'json'
 				]
@@ -59,7 +61,8 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--ignore', 'warning',
 					'--ignore', 'notice',
 					'--reporter', 'json'
@@ -83,7 +86,8 @@ describe('CLI ignore', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--ignore', 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/output.js
+++ b/test/integration/cli/output.js
@@ -54,12 +54,13 @@ describe('CLI output', () => {
 
 	});
 
-	describe('when Pa11y is run on a page with errors, warnings, and notices and the `--include-non-errors` flag is set', () => {
+	describe('when Pa11y is run on a page with errors, warnings, and notices and the `--include-notices`/`--include-warnings` flags are set', () => {
 
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--reporter', 'json'
 				]
 			});

--- a/test/integration/cli/output.js
+++ b/test/integration/cli/output.js
@@ -21,6 +21,52 @@ describe('CLI output', () => {
 
 		it('outputs the expected issues', () => {
 			assert.isArray(pa11yResponse.json);
+			assert.lengthEquals(pa11yResponse.json, 1);
+		});
+
+		it('does not output notices', () => {
+			const notices = pa11yResponse.json.filter(foundIssue => foundIssue.type === 'notice');
+			assert.lengthEquals(notices, 0);
+		});
+
+		it('does not output warnings', () => {
+			const warnings = pa11yResponse.json.filter(foundIssue => foundIssue.type === 'warning');
+			assert.lengthEquals(warnings, 0);
+		});
+
+		it('outputs errors', () => {
+			const issue = pa11yResponse.json.find(foundIssue => foundIssue.type === 'error');
+			assert.isObject(issue);
+
+			// Issue code
+			assert.isString(issue.code);
+			assert.match(issue.code, /^WCAG2AA\./);
+
+			// Issue message, context, and selector
+			assert.isString(issue.message);
+			assert.strictEqual(issue.context, '<html><head>\n\n\t<meta charset="utf-8">...</html>');
+			assert.strictEqual(issue.selector, 'html');
+
+			// Issue type
+			assert.strictEqual(issue.type, 'error');
+			assert.strictEqual(issue.typeCode, 1);
+		});
+
+	});
+
+	describe('when Pa11y is run on a page with errors, warnings, and notices and the `--include-non-errors` flag is set', () => {
+
+		before(async () => {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--include-non-errors',
+					'--reporter', 'json'
+				]
+			});
+		});
+
+		it('outputs the expected issues', () => {
+			assert.isArray(pa11yResponse.json);
 			assert.lengthEquals(pa11yResponse.json, 3);
 		});
 
@@ -85,8 +131,7 @@ describe('CLI output', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/selectors`, {
 				arguments: [
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/integration/cli/reporter-csv.js
+++ b/test/integration/cli/reporter-csv.js
@@ -11,6 +11,7 @@ describe('CLI reporter CSV', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--reporter', 'csv'
 				]
 			});

--- a/test/integration/cli/reporter-csv.js
+++ b/test/integration/cli/reporter-csv.js
@@ -11,7 +11,8 @@ describe('CLI reporter CSV', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--reporter', 'csv'
 				]
 			});

--- a/test/integration/cli/reporter-json.js
+++ b/test/integration/cli/reporter-json.js
@@ -19,7 +19,7 @@ describe('CLI reporter JSON', () => {
 		it('outputs issues in JSON format', () => {
 			const json = JSON.parse(pa11yResponse.output);
 			assert.isArray(json);
-			assert.lengthEquals(json, 3);
+			assert.lengthEquals(json, 1);
 		});
 
 	});

--- a/test/integration/cli/root-element.js
+++ b/test/integration/cli/root-element.js
@@ -32,6 +32,7 @@ describe('CLI root-element', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/root-element`, {
 				arguments: [
+					'--include-non-errors',
 					'--root-element', '#not-a-real-thing',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/root-element.js
+++ b/test/integration/cli/root-element.js
@@ -32,7 +32,8 @@ describe('CLI root-element', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/root-element`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--root-element', '#not-a-real-thing',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/standard.js
+++ b/test/integration/cli/standard.js
@@ -14,7 +14,8 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--standard', 'WCAG2A',
 					'--reporter', 'json'
 				]
@@ -36,7 +37,8 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--standard', 'WCAG2AAA',
 					'--reporter', 'json'
 				]
@@ -58,7 +60,8 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
-					'--include-non-errors',
+					'--include-notices',
+					'--include-warnings',
 					'--standard', 'Section508',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/standard.js
+++ b/test/integration/cli/standard.js
@@ -14,6 +14,7 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--standard', 'WCAG2A',
 					'--reporter', 'json'
 				]
@@ -35,6 +36,7 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--standard', 'WCAG2AAA',
 					'--reporter', 'json'
 				]
@@ -56,6 +58,7 @@ describe('CLI standard', () => {
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
 				arguments: [
+					'--include-non-errors',
 					'--standard', 'Section508',
 					'--reporter', 'json'
 				]

--- a/test/integration/cli/wait.js
+++ b/test/integration/cli/wait.js
@@ -15,8 +15,7 @@ describe('CLI wait', () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/wait`, {
 				arguments: [
 					'--wait', '2100',
-					'--reporter', 'json',
-					'--ignore', 'warning;notice' // This is so we only deal with errors
+					'--reporter', 'json'
 				]
 			});
 		});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -121,7 +121,10 @@ describe('lib/pa11y', () => {
 			assert.isFunction(puppeteer.mockPage.evaluate.firstCall.args[0]);
 			assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1], {
 				hideElements: pa11y.defaults.hideElements,
-				ignore: pa11y.defaults.ignore,
+				ignore: [
+					'notice',
+					'warning'
+				],
 				rootElement: pa11y.defaults.rootElement,
 				rules: pa11y.defaults.rules,
 				standard: pa11y.defaults.standard,
@@ -282,15 +285,46 @@ describe('lib/pa11y', () => {
 			beforeEach(async () => {
 				extend.reset();
 				options.ignore = [
-					'WARNING'
+					'MOCK-IGNORE'
 				];
 				await pa11y(options);
 			});
 
 			it('lowercases them', () => {
-				assert.deepEqual(extend.firstCall.args[0].ignore, [
+				assert.include(extend.firstCall.args[0].ignore, 'mock-ignore');
+			});
+
+		});
+
+		describe('when `options.includeNonErrors` is `false`', () => {
+
+			beforeEach(async () => {
+				puppeteer.mockPage.evaluate.resetHistory();
+				options.ignore = [];
+				options.includeNonErrors = false;
+				await pa11y(options);
+			});
+
+			it('automatically ignores warnings and notices', () => {
+				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, [
+					'notice',
 					'warning'
 				]);
+			});
+
+		});
+
+		describe('when `options.includeNonErrors` is `true`', () => {
+
+			beforeEach(async () => {
+				puppeteer.mockPage.evaluate.resetHistory();
+				options.ignore = [];
+				options.includeNonErrors = true;
+				await pa11y(options);
+			});
+
+			it('does not automatically ignore warnings and notices', () => {
+				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, []);
 			});
 
 		});
@@ -493,6 +527,10 @@ describe('lib/pa11y', () => {
 
 		it('has an `ignore` property', () => {
 			assert.deepEqual(pa11y.defaults.ignore, []);
+		});
+
+		it('has an `includeNonErrors` property', () => {
+			assert.isFalse(pa11y.defaults.includeNonErrors);
 		});
 
 		it('has a `log` property', () => {

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -296,16 +296,16 @@ describe('lib/pa11y', () => {
 
 		});
 
-		describe('when `options.includeNonErrors` is `false`', () => {
+		describe('when `options.includeNotices` is `false`', () => {
 
 			beforeEach(async () => {
 				puppeteer.mockPage.evaluate.resetHistory();
 				options.ignore = [];
-				options.includeNonErrors = false;
+				options.includeNotices = false;
 				await pa11y(options);
 			});
 
-			it('automatically ignores warnings and notices', () => {
+			it('automatically ignores notices', () => {
 				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, [
 					'notice',
 					'warning'
@@ -314,17 +314,54 @@ describe('lib/pa11y', () => {
 
 		});
 
-		describe('when `options.includeNonErrors` is `true`', () => {
+		describe('when `options.includeNotices` is `true`', () => {
 
 			beforeEach(async () => {
 				puppeteer.mockPage.evaluate.resetHistory();
 				options.ignore = [];
-				options.includeNonErrors = true;
+				options.includeNotices = true;
 				await pa11y(options);
 			});
 
-			it('does not automatically ignore warnings and notices', () => {
-				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, []);
+			it('does not automatically ignore notices', () => {
+				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, [
+					'warning'
+				]);
+			});
+
+		});
+
+		describe('when `options.includeWarnings` is `false`', () => {
+
+			beforeEach(async () => {
+				puppeteer.mockPage.evaluate.resetHistory();
+				options.ignore = [];
+				options.includeWarnings = false;
+				await pa11y(options);
+			});
+
+			it('automatically ignores warnings', () => {
+				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, [
+					'notice',
+					'warning'
+				]);
+			});
+
+		});
+
+		describe('when `options.includeWarnings` is `true`', () => {
+
+			beforeEach(async () => {
+				puppeteer.mockPage.evaluate.resetHistory();
+				options.ignore = [];
+				options.includeWarnings = true;
+				await pa11y(options);
+			});
+
+			it('does not automatically ignore warnings', () => {
+				assert.deepEqual(puppeteer.mockPage.evaluate.firstCall.args[1].ignore, [
+					'notice'
+				]);
 			});
 
 		});
@@ -529,8 +566,12 @@ describe('lib/pa11y', () => {
 			assert.deepEqual(pa11y.defaults.ignore, []);
 		});
 
-		it('has an `includeNonErrors` property', () => {
-			assert.isFalse(pa11y.defaults.includeNonErrors);
+		it('has an `includeNotices` property', () => {
+			assert.isFalse(pa11y.defaults.includeNotices);
+		});
+
+		it('has an `includeWarnings` property', () => {
+			assert.isFalse(pa11y.defaults.includeWarnings);
 		});
 
 		it('has a `log` property', () => {


### PR DESCRIPTION
We now ignore warnings and notices by default, they get added into the
ignore array once all the options have been defaulted.

I've added a way to continue including them if people want that, this is
just a change in the default behaviour.

Resolves #170