### PR TITLE
Backport the reporter compatibility check

### DIFF
--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -6,6 +6,7 @@ var path = require('path');
 var pkg = require('../package.json');
 var program = require('commander');
 var pa11y = require('../lib/pa11y');
+var semver = require('semver');
 
 configureProgram(program);
 runProgram(program);
@@ -175,7 +176,18 @@ function loadReporter(name) {
 		console.error('Reporter "' + name + '" could not be found');
 		process.exit(1);
 	}
+	checkReporterCompatibility(name, reporter.supports, pkg.version);
 	return reporter;
+}
+
+function checkReporterCompatibility(reporterName, reporterSupportString, pa11yVersion) {
+	if (reporterSupportString && !semver.satisfies(pa11yVersion, reporterSupportString)) {
+		console.error('Error: The installed "' + reporterName + '" reporter does not support Pa11y ' + pa11yVersion);
+		console.error('Please update your version of Pa11y to use this reporter');
+		console.error('Reporter Support: ' + reporterSupportString);
+		console.error('Pa11y Version:    ' + pa11yVersion);
+		process.exit(1);
+	}
 }
 
 function requireFirst(stack, defaultReturn) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node.extend": "^1.1.6",
     "once": "^1.4.0",
     "phantomjs-prebuilt": "^2.1.12",
+    "semver": "^5.4.1",
     "truffler": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This backports the reporter compatibility check from Pa11y 5.x. Pa11y
4.x will now output a useful error if you try to use a reporter which
only supports Pa11y 5 and above.