### PR TITLE
Output browser console messages to the debug log

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -2,6 +2,7 @@
 
 const runAction = require('./action');
 const extend = require('node.extend');
+const inspect = require('util').inspect;
 const path = require('path');
 const pkg = require('../package.json');
 const promiseTimeout = require('p-timeout');
@@ -124,6 +125,13 @@ async function runPa11yTest(url, options, state) {
 			interceptionHandled = true;
 		}
 		interceptedRequest.continue(overrides);
+	});
+
+	// Listen for console logs on the page so that we can
+	// output them for debugging purposes
+	page.on('console', (...args) => {
+		const message = args.map(inspect).join(' ');
+		options.log.debug(`Browser Console: ${message}`);
 	});
 
 	// Navigate to the URL we're going to test

--- a/test/unit/mock/util.js
+++ b/test/unit/mock/util.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	inspect: sinon.stub()
+};


### PR DESCRIPTION
This is possible now that we're using Headless Chrome. This should aid
Pa11y users (and us) in debugging issues.

Resolves #233