### PR TITLE
Add an action to capture a screen-grab

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ pa11y('http://example.com/', {
         'set field #fullname to John Doe',
         'check field #terms-and-conditions',
         'uncheck field #subscribe-to-marketing',
+        'screen capture example.png',
         'wait for fragment to be #page-2',
         'wait for path to not be /login',
         'wait for url to be https://example.com/'
@@ -667,6 +668,18 @@ pa11y('http://example.com/', {
     actions: [
         'check field #terms-and-conditions',
         'uncheck field #subscribe-to-marketing'
+    ]
+});
+```
+
+### Screen Capture
+
+This allows you to capture the screen between other actions, useful to verify that the page looks as you expect before the Pa11y test runs. This action takes the form `screen capture <file-path>`. E.g.
+
+```js
+pa11y('http://example.com/', {
+    actions: [
+        'screen capture example.png'
     ]
 });
 ```

--- a/lib/action.js
+++ b/lib/action.js
@@ -120,6 +120,20 @@ module.exports.actions = [
 		}
 	},
 
+	// Action to screen capture the page to a file
+	// E.g. "screen-capture example.png"
+	// E.g. "capture screen to example.png"
+	{
+		name: 'screen-capture',
+		match: /^(screen[ -]?capture|capture[ -]?screen)( to)? (.+)$/i,
+		run: async (browser, page, options, matches) => {
+			await page.screenshot({
+				path: matches[3],
+				fullPage: true
+			});
+		}
+	},
+
 	// Action which waits for the URL, path, or fragment to change to the given value
 	// E.g. "wait for fragment to be #example"
 	// E.g. "wait for path to be /example"

--- a/test/integration/cli/actions-screen-capture.js
+++ b/test/integration/cli/actions-screen-capture.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('proclaim');
+const fs = require('fs');
+const path = require('path');
+const promisify = require('util').promisify;
+const runPa11yCli = require('../helper/pa11y-cli');
+const mkdir = promisify(fs.mkdir);
+const rmdir = promisify(fs.rmdir);
+const stat = promisify(fs.stat);
+const unlink = promisify(fs.unlink);
+
+// Note: we use the JSON reporter in here to make it easier
+// to inspect the output issues. The regular CLI output is
+// tested in the reporter tests
+describe('CLI action "screen-capture"', () => {
+	let screenCaptureDirectory;
+	let screenCapturePath;
+
+	before(async () => {
+		screenCaptureDirectory = path.join(__dirname, '/../tmp');
+		screenCapturePath = path.join(screenCaptureDirectory, '/test.png');
+		try {
+			await mkdir(screenCaptureDirectory);
+		} catch (error) {}
+		await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+			arguments: [
+				// Config path is relative to working directory
+				'--config', '../mock/config/actions-screen-capture.json',
+				'--reporter', 'json'
+			],
+			workingDirectory: screenCaptureDirectory
+		});
+	});
+
+	after(async () => {
+		await unlink(screenCapturePath);
+		await rmdir(screenCaptureDirectory);
+	});
+
+	it('saves a screen capture to the expected file', async () => {
+		const stats = await stat(screenCapturePath);
+		assert.isTrue(stats.isFile());
+	});
+
+});

--- a/test/integration/mock/config/actions-screen-capture.json
+++ b/test/integration/mock/config/actions-screen-capture.json
@@ -1,0 +1,5 @@
+{
+	"actions": [
+		"screen-capture test.png"
+	]
+}


### PR DESCRIPTION
This allows a Pa11y user to verify that the page looks correct at different points in the test run.