### PR TITLE
Integrate update-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Need a GUI? Try [Koa11y](https://open-indy.github.io/Koa11y/)!
 
 ## Latest news from Pa11y
 
-We're pleased to announce the Pa11y 5.0 beta is now available! We're switching from PhantomJS to Headless Chrome, as well as many other changes. See the [migration guide][migration-5] for further details. 
+We're pleased to announce the Pa11y 5.0 beta is now available! We're switching from PhantomJS to Headless Chrome, as well as many other changes. See the [migration guide][migration-5] for further details.
 
 If you'd like to try out the Pa11y 5.0 beta you can do so with
 
@@ -123,6 +123,7 @@ Usage: pa11y [options] <url>
     -e, --phantomjs <path>         the path to the phantomjs executable
     -S, --screen-capture <path>    a path to save a screen capture of the page to
     -A, --add-rule <rule>          WCAG 2.0 rules from a different standard to include, a repeatable value or separated by semi-colons
+    -P, --no-package-version-check prevent check on whether the latest version of pa11y is installed
 ```
 
 ### Running Tests
@@ -672,7 +673,7 @@ pa11y({
     ]
 });
 ```
-You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), including classes and types. 
+You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), including classes and types.
 
 ### Set Field Value
 

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -96,8 +96,8 @@ function configureProgram(program) {
 			[]
 		)
 		.option(
-			'-P, --do-not-check-package-version',
-			'prevent check against latest released version'
+			'-P, --no-package-version-check',
+			'prevent check on whether the latest version of pa11y is installed'
 		)
 		.parse(process.argv);
 	program.url = program.args[0];

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -253,6 +253,8 @@ function outputEnvironmentInfo() {
 
 function checkPackageVersion(program) {
 	if (!program.doNotCheckPackageVersion) {
-		updateNotifier({pkg}).notify();
+		updateNotifier({
+			pkg: pkg
+		}).notify();
 	}
 }

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -9,7 +9,6 @@ var pa11y = require('../lib/pa11y');
 var semver = require('semver');
 var updateNotifier = require('update-notifier');
 
-checkPackageVersion();
 configureProgram(program);
 runProgram(program);
 
@@ -96,6 +95,10 @@ function configureProgram(program) {
 			collectOptions,
 			[]
 		)
+		.option(
+			'-P, --do-not-check-package-version',
+			'prevent check against latest released version'
+		)
 		.parse(process.argv);
 	program.url = program.args[0];
 }
@@ -108,6 +111,7 @@ function runProgram(program) {
 	if (!program.url || program.args[1]) {
 		program.help();
 	}
+	checkPackageVersion(program);
 	var options = processOptions(program);
 	options.log.begin(program.url);
 	try {
@@ -247,11 +251,8 @@ function outputEnvironmentInfo() {
 	console.log('OS:         ' + versions.os + ' (' + process.platform + ')');
 }
 
-function checkPackageVersion() {
-	updateNotifier({
-		pkg: {
-			name: 'pa11y',
-			version: pkg.version
-		}
-	}).notify();
+function checkPackageVersion(program) {
+	if (!program.doNotCheckPackageVersion) {
+		updateNotifier({pkg}).notify();
+	}
 }

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -7,7 +7,9 @@ var pkg = require('../package.json');
 var program = require('commander');
 var pa11y = require('../lib/pa11y');
 var semver = require('semver');
+var updateNotifier = require('update-notifier');
 
+checkPackageVersion();
 configureProgram(program);
 runProgram(program);
 
@@ -243,4 +245,13 @@ function outputEnvironmentInfo() {
 	console.log('npm:        ' + versions.npm);
 	console.log('PhantomJS:  ' + versions.phantom);
 	console.log('OS:         ' + versions.os + ' (' + process.platform + ')');
+}
+
+function checkPackageVersion() {
+	updateNotifier({
+		pkg: {
+			name: 'pa11y',
+			version: pkg.version
+		}
+	}).notify();
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "once": "^1.4.0",
     "phantomjs-prebuilt": "^2.1.12",
     "semver": "^5.4.1",
-    "truffler": "^3.1.0"
+    "truffler": "^3.1.0",
+    "update-notifier": "^2.3.0"
   },
   "devDependencies": {
     "eslint": "^3.18.0",

--- a/test/integration/helper/describe-cli-call.js
+++ b/test/integration/helper/describe-cli-call.js
@@ -20,7 +20,7 @@ function describeCliCall(urlPath, cliArguments, environment, testFunction) {
 			if (cliArguments.indexOf('--reporter') === -1 && cliArguments.indexOf('-r') === -1) {
 				cliArguments.push('--reporter', 'json');
 			}
-			cliArguments.push('--do-not-check-package-version');
+			cliArguments.push('--no-package-version-check');
 			var child = spawn('../../bin/pa11y', cliArguments, {
 				cwd: path.resolve(__dirname, '../'),
 				env: environment

--- a/test/integration/helper/describe-cli-call.js
+++ b/test/integration/helper/describe-cli-call.js
@@ -20,7 +20,7 @@ function describeCliCall(urlPath, cliArguments, environment, testFunction) {
 			if (cliArguments.indexOf('--reporter') === -1 && cliArguments.indexOf('-r') === -1) {
 				cliArguments.push('--reporter', 'json');
 			}
-
+			cliArguments.push('--do-not-check-package-version');
 			var child = spawn('../../bin/pa11y', cliArguments, {
 				cwd: path.resolve(__dirname, '../'),
 				env: environment


### PR DESCRIPTION
@rowanmanning Thought I'd have a go at this [issue](https://github.com/pa11y/pa11y/issues/254).

- Runs [update-notifier](https://www.npmjs.com/package/update-notifier) when pa11y initiated from CLI.
- Only active when running pa11y (not run if just checking environment details or getting help).
- Option (-P) created to enable user to prevent the update check from running.
- Prevention option incorporated into the CLI integration tests to prevent it running during tests.
- Uses default set up to run 1/day and standard messaging.

Have not put in any testing of this function - didn't seem to fall into the scope of integration tests and there don't seem to be any explicit unit tests for the exclusively CLI functions - unless I was missing them. Happy to follow any recommendation that you have for testing.

Can take a look at the similar issue for [pa11y-ci](https://github.com/pa11y/pa11y-ci/issues/21) once this gets through.