### PR TITLE
Adding a new action for redirecting to a specified url

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,8 @@ pa11y('http://example.com/', {
         'wait for fragment to be #page-2',
         'wait for path to not be /login',
         'wait for url to be https://example.com/',
-        'wait for #my-image to emit load'
+        'wait for #my-image to emit load',
+        'navigate to https://another-example.com/'
     ]
 });
 ```
@@ -776,6 +777,18 @@ pa11y('http://example.com/', {
     actions: [
         'click element #tab-2',
         'wait for element #tab-panel-to to emit content-loaded'
+    ]
+});
+```
+
+### Navigate To URL
+
+This action allows you to navigate to a new URL if, for example, the URL is inaccessible using other methods. This action takes the form `navigate to <url>`. E.g.
+
+```js
+pa11y('http://example.com/', {
+    actions: [
+        'navigate to http://another-example.com'
     ]
 });
 ```

--- a/lib/action.js
+++ b/lib/action.js
@@ -48,6 +48,21 @@ function isValidAction(actionString) {
  */
 module.exports.actions = [
 
+	// Action to redirect to a url
+	// E.g. "redirect to http://pa11y.org"
+	{
+		name: 'redirect-url',
+		match: /^redirect to( url)? (.+)$/i,
+		run: async (browser, page, options, matches) => {
+			const redirectTo = matches[2];
+			try {
+				await page.goto(redirectTo);
+			} catch (error) {
+				throw new Error(`Failed action: Could not redirect to "${redirectTo}"`);
+			}
+		}
+	},
+
 	// Action to click an element
 	// E.g. "click .sign-in-button"
 	{

--- a/lib/action.js
+++ b/lib/action.js
@@ -48,17 +48,17 @@ function isValidAction(actionString) {
  */
 module.exports.actions = [
 
-	// Action to redirect to a url
-	// E.g. "redirect to http://pa11y.org"
+	// Action to navigate to a url
+	// E.g. "navigate to http://pa11y.org"
 	{
-		name: 'redirect-url',
-		match: /^redirect to( url)? (.+)$/i,
+		name: 'navigate-url',
+		match: /^navigate to( url)? (.+)$/i,
 		run: async (browser, page, options, matches) => {
-			const redirectTo = matches[2];
+			const navigateTo = matches[2];
 			try {
-				await page.goto(redirectTo);
+				await page.goto(navigateTo);
 			} catch (error) {
-				throw new Error(`Failed action: Could not redirect to "${redirectTo}"`);
+				throw new Error(`Failed action: Could not navigate to "${navigateTo}"`);
 			}
 		}
 	},

--- a/test/unit/lib/action.test.js
+++ b/test/unit/lib/action.test.js
@@ -131,17 +131,17 @@ describe('lib/action', () => {
 
 	});
 
-	describe('redirect-url action', () => {
+	describe('navigate-url action', () => {
 		let action;
 
 		beforeEach(() => {
 			action = runAction.actions.find(foundAction => {
-				return foundAction.name === 'redirect-url';
+				return foundAction.name === 'navigate-url';
 			});
 		});
 
 		it('has a name property', () => {
-			assert.strictEqual(action.name, 'redirect-url');
+			assert.strictEqual(action.name, 'navigate-url');
 		});
 
 		it('has a match property', () => {
@@ -150,8 +150,8 @@ describe('lib/action', () => {
 
 		describe('.match', () => {
 			it('matches all of the expected action strings', () => {
-				assert.deepEqual('redirect to http://pa11y.org'.match(action.match), [
-					'redirect to http://pa11y.org',
+				assert.deepEqual('navigate to http://pa11y.org'.match(action.match), [
+					'navigate to http://pa11y.org',
 					undefined,
 					'http://pa11y.org'
 				]);
@@ -167,7 +167,7 @@ describe('lib/action', () => {
 			let resolvedValue;
 
 			beforeEach(async () => {
-				matches = 'redirect to http://pa11y.org'.match(action.match);
+				matches = 'navigate to http://pa11y.org'.match(action.match);
 				resolvedValue = await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
 			});
 
@@ -181,12 +181,12 @@ describe('lib/action', () => {
 			});
 
 			describe('when the click fails', () => {
-				let redirectError;
+				let navigateError;
 				let rejectedError;
 
 				beforeEach(async () => {
-					redirectError = new Error('redirect to error');
-					puppeteer.mockPage.goto.rejects(redirectError);
+					navigateError = new Error('navigate to error');
+					puppeteer.mockPage.goto.rejects(navigateError);
 					try {
 						await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
 					} catch (error) {
@@ -195,9 +195,9 @@ describe('lib/action', () => {
 				});
 
 				it('rejects with a new error', () => {
-					assert.notStrictEqual(rejectedError, redirectError);
+					assert.notStrictEqual(rejectedError, navigateError);
 					assert.instanceOf(rejectedError, Error);
-					assert.strictEqual(rejectedError.message, 'Failed action: Could not redirect to "http://pa11y.org"');
+					assert.strictEqual(rejectedError.message, 'Failed action: Could not navigate to "http://pa11y.org"');
 				});
 			});
 		});


### PR DESCRIPTION
We have a case where we are using the existing actions to log into an app by filling in fields and clicking submit buttons. Once logged in the app redirects to a landing page but this is not the page we want to run Pa11y against. There is another page, that you need to be authenticated to view (hence the logging in steps), that you can't get to directly from the landing page.

This new 'redirect' action e.g. "redirect to http://pa11y.org/" allows us to specify a new url to goto once our login actions have finished running.

Hopefully useful for others with similar circumstances...