### PR TITLE
Allow sharing a Chrome browser instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,30 @@ pa11y('http://example.com/', {
 
 Defaults to an empty array.
 
+### `browser` (Browser)
+
+A [Puppeteer Browser instance][puppeteer-browser] which will be used in the test run. If this is provided then there are several things you need to consider:
+
+  1. Pa11y's `chromeLaunchConfig` option will be ignored, you'll need to pass this configuration in when you create your Browser instance
+  2. Pa11y will not automatically close the Browser when the tests have finished running, you will need to do this yourself if you need the Node.js process to exit
+  3. It's important that you use a version of Puppeteer that meets the range specified in Pa11y's `package.json`
+
+**Note:** This is an advanced option. If you're using this, please mention in any issues you open on Pa11y and double-check that the Puppeteer version you're using matches Pa11y's.
+
+```js
+const browser = await puppeteer.launch({
+    ignoreHTTPSErrors: true
+});
+
+pa11y('http://example.com/', {
+    browser: browser
+});
+
+browser.close();
+```
+
+Defaults to `null`.
+
 ### `chromeLaunchConfig` (object)
 
 Launch options for the Headless Chrome instance. [See the Puppeteer documentation for more information][puppeteer-launch].
@@ -886,6 +910,7 @@ Copyright &copy; 2013–2017, Team Pa11y and contributors
 [node]: http://nodejs.org/
 [npm]: https://www.npmjs.com/
 [promise]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[puppeteer-browser]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browser
 [puppeteer-launch]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
 [puppeteer-viewport]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport
 [semver range]: https://github.com/npm/node-semver#ranges

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -58,7 +58,7 @@ async function pa11y(url, options = {}, callback) {
 		return results;
 
 	} catch (error) {
-		if (state.browser) {
+		if (state.browser && state.autoClose) {
 			state.browser.close();
 		}
 
@@ -82,11 +82,24 @@ async function runPa11yTest(url, options, state) {
 
 	options.log.info(`Running Pa11y on URL ${url}`);
 
-	// Launch a Headless Chrome browser and create a page
-	// We use a state object which is accessible from the
-	// wrapping function
-	options.log.debug('Launching Headless Chrome');
-	const browser = state.browser = await puppeteer.launch(options.chromeLaunchConfig);
+	// Check whether we have a browser already
+	let browser;
+	if (options.browser) {
+		options.log.debug('Using a pre-configured Headless Chrome instance, the `chromeLaunchConfig` option will be ignored');
+		browser = state.browser = options.browser;
+		state.autoClose = false;
+	} else {
+
+		// Launch a Headless Chrome browser. We use a
+		// state object which is accessible from the
+		// wrapping function
+		options.log.debug('Launching Headless Chrome');
+		browser = state.browser = await puppeteer.launch(options.chromeLaunchConfig);
+		state.autoClose = true;
+
+	}
+
+	// Create a page
 	const page = await browser.newPage();
 
 	// Intercept page requests, we need to do this in order
@@ -194,7 +207,9 @@ async function runPa11yTest(url, options, state) {
 	}
 
 	// Close the browser and return the Pa11y results
-	browser.close();
+	if (state.autoClose) {
+		browser.close();
+	}
 	return results;
 }
 
@@ -262,6 +277,7 @@ const noop = () => {};
  */
 pa11y.defaults = {
 	actions: [],
+	browser: null,
 	chromeLaunchConfig: {
 		ignoreHTTPSErrors: true
 	},

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -580,6 +580,34 @@ describe('lib/pa11y', () => {
 
 		});
 
+		describe('when `options.browser` is set', () => {
+
+			beforeEach(async () => {
+				extend.reset();
+				puppeteer.launch.resetHistory();
+				puppeteer.mockBrowser.newPage.resetHistory();
+				options.browser = {
+					close: sinon.stub(),
+					newPage: sinon.stub().resolves(puppeteer.mockPage)
+				};
+				await pa11y(options);
+			});
+
+			it('does not launch puppeteer', () => {
+				assert.notCalled(puppeteer.launch);
+			});
+
+			it('creates a new page using the passed in browser', () => {
+				assert.calledOnce(options.browser.newPage);
+				assert.calledWithExactly(options.browser.newPage);
+			});
+
+			it('does not close the browser', () => {
+				assert.notCalled(options.browser.close);
+			});
+
+		});
+
 	});
 
 	describe('pa11y(url, options)', () => {
@@ -665,6 +693,10 @@ describe('lib/pa11y', () => {
 
 		it('has an `actions` property', () => {
 			assert.deepEqual(pa11y.defaults.actions, []);
+		});
+
+		it('has a `browser` property', () => {
+			assert.isNull(pa11y.defaults.browser);
 		});
 
 		it('has a `chromeLaunchConfig` property', () => {


### PR DESCRIPTION
This PR adds the ability to pass in a Puppeteer Browser instance to be
shared across multiple Pa11y test runs, this should be less resource
intensive and we need this work in place for Pa11y CI and probably
Sidekick.

I've added some warnings to the README for anyone using this themselves,
but mostly I think it'll be used by our own derivative projects.

Resolves #298