### PR TITLE
Fix Content-Security-Policy issues

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -2,10 +2,14 @@
 
 const runAction = require('./action');
 const extend = require('node.extend');
+const fs = require('fs-extra');
 const path = require('path');
 const pkg = require('../package.json');
 const promiseTimeout = require('p-timeout');
 const puppeteer = require('puppeteer');
+
+let htmlCodeSnifferJavaScript;
+let pa11yRunnerJavaScript;
 
 module.exports = pa11y;
 
@@ -165,11 +169,21 @@ async function runPa11yTest(url, options, state) {
 		options.log.info('Finished running actions');
 	}
 
+	// Load the HTML CodeSniffer and Pa11y client-side scripts if required
+	// We only load these files once on the first run of Pa11y as they don't
+	// change between runs
+	if (!htmlCodeSnifferJavaScript) {
+		htmlCodeSnifferJavaScript = await fs.readFile(`${__dirname}/vendor/HTMLCS.js`, 'utf-8');
+	}
+	if (!pa11yRunnerJavaScript) {
+		pa11yRunnerJavaScript = await fs.readFile(`${__dirname}/runner.js`, 'utf-8');
+	}
+
 	// Inject HTML CodeSniffer and the Pa11y test runner
 	options.log.debug('Injecting HTML CodeSniffer');
-	await page.addScriptTag({path: `${__dirname}/vendor/HTMLCS.js`});
+	await page.evaluate(htmlCodeSnifferJavaScript);
 	options.log.debug('Injecting Pa11y');
-	await page.addScriptTag({path: `${__dirname}/runner.js`});
+	await page.evaluate(pa11yRunnerJavaScript);
 
 	// Launch the test runner!
 	options.log.debug('Running Pa11y on the page');

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,6 +706,16 @@
         "samsam": "1.3.0"
       }
     },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -762,8 +772,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -1019,6 +1028,14 @@
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3279,6 +3296,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
+    "fs-extra": "^5.0.0",
     "node.extend": "^2.0.0",
     "p-timeout": "^1.2.0",
     "pa11y-reporter-cli": "^1.0.0",

--- a/test/unit/mock/fs-extra.mock.js
+++ b/test/unit/mock/fs-extra.mock.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	readFile: sinon.stub()
+};


### PR DESCRIPTION
Headless Chrome enforces content security policies, which means that
injected script tags are sometimes blocked from running. This causes
issues for Pa11y and prevents it from running on a LOT of pages.

This PR switches from injected scripts to evaluating the JavaScript
files as strings, which fixes the issue.

I've tested with the reported URLs as well as my own test pages which
have very strict content security policies.

Fixes #364.