### PR TITLE
Support `options.page`

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -64,6 +64,8 @@ async function pa11y(url, options = {}, callback) {
 	} catch (error) {
 		if (state.browser && state.autoClose) {
 			state.browser.close();
+		} else if (state.page && state.autoClosePage) {
+			state.page.close();
 		}
 
 		// Run callback if present, and reject with error
@@ -105,10 +107,10 @@ async function runPa11yTest(url, options, state) {
 	}
 
 	if (options.browser && options.page) {
-		page = options.page;
+		page = state.page = options.page;
 		state.autoClosePage = false;
 	} else {
-		page = await browser.newPage();
+		page = state.page = await browser.newPage();
 		state.autoClosePage = true;
 	}
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -88,6 +88,7 @@ async function runPa11yTest(url, options, state) {
 
 	// Check whether we have a browser already
 	let browser;
+	let page;
 	if (options.browser) {
 		options.log.debug('Using a pre-configured Headless Chrome instance, the `chromeLaunchConfig` option will be ignored');
 		browser = state.browser = options.browser;
@@ -103,8 +104,13 @@ async function runPa11yTest(url, options, state) {
 
 	}
 
-	// Create a page
-	const page = await browser.newPage();
+	if (options.browser && options.page) {
+		page = options.page;
+		state.autoClosePage = false;
+	} else {
+		page = await browser.newPage();
+		state.autoClosePage = true;
+	}
 
 	// Intercept page requests, we need to do this in order
 	// to set the HTTP method or post data
@@ -222,7 +228,9 @@ async function runPa11yTest(url, options, state) {
 
 	// Close the browser and return the Pa11y results
 	if (state.autoClose) {
-		browser.close();
+		await browser.close();
+	} else if (state.autoClosePage) {
+		await page.close();
 	}
 	return results;
 }

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -609,6 +609,8 @@ describe('lib/pa11y', () => {
 				extend.reset();
 				puppeteer.launch.resetHistory();
 				puppeteer.mockBrowser.newPage.resetHistory();
+				puppeteer.mockBrowser.close.resetHistory();
+				puppeteer.mockPage.close.resetHistory();
 				options.browser = {
 					close: sinon.stub(),
 					newPage: sinon.stub().resolves(puppeteer.mockPage)
@@ -627,6 +629,41 @@ describe('lib/pa11y', () => {
 
 			it('does not close the browser', () => {
 				assert.notCalled(options.browser.close);
+			});
+
+			it('closes the page', () => {
+				assert.calledOnce(puppeteer.mockPage.close);
+			});
+
+		});
+
+		describe('when `options.page` is set', () => {
+
+			beforeEach(async () => {
+				extend.reset();
+				puppeteer.launch.resetHistory();
+				puppeteer.mockBrowser.newPage.resetHistory();
+				puppeteer.mockBrowser.close.resetHistory();
+				puppeteer.mockPage.close.resetHistory();
+				options.browser = puppeteer.mockBrowser;
+				options.page = puppeteer.mockPage;
+				await pa11y(options);
+			});
+
+			it('does not launch puppeteer', () => {
+				assert.notCalled(puppeteer.launch);
+			});
+
+			it('does not open the page', () => {
+				assert.notCalled(options.browser.newPage);
+			});
+
+			it('does not close the browser', () => {
+				assert.notCalled(options.browser.close);
+			});
+
+			it('does not close the page', () => {
+				assert.notCalled(options.page.close);
 			});
 
 		});

--- a/test/unit/mock/puppeteer.mock.js
+++ b/test/unit/mock/puppeteer.mock.js
@@ -12,6 +12,7 @@ const mockBrowser = puppeteer.mockBrowser = {
 };
 
 const mockPage = puppeteer.mockPage = {
+	close: sinon.stub().resolves(),
 	click: sinon.stub().resolves(),
 	evaluate: sinon.stub().resolves(),
 	focus: sinon.stub().resolves(),


### PR DESCRIPTION
This PR aims to achieve 2 main issues

1.- I noticed that if the actions part of the test fails the whole function will throw and the promise will be rejected, causing the process to end and close the browser, however its impossible to access the page at that point. This PR makes it so I can take screenshots of the page when errors are thrown because I would own the page.
2.- Also noticed that if the browser passed then the page created by the test will never close and would hoard memory. Causing long-lasting browser instances to keep these pages running forever.