### PR TITLE
Fix the _runPa11y not defined error

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -251,4 +251,4 @@
 
 	}
 
-})(typeof module !== 'undefined' && module.exports ? module.exports : window));
+})(this));


### PR DESCRIPTION
This fixes the common error `_runPa11y is not defined`. This is caused
when a page that's being tested includes a global `module.exports`
property. It seems Pa11y was getting into a race condition with the
site's JavaScript code - if Pa11y loaded first, it was fine. If it
loadded second, then it would add the Pa11y code to `module.exports`
rather than `window`.

This fixes #392. Thanks to @jakechampion for the suggestion