### PR TITLE
Clarify rootElement behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,14 +546,14 @@ Defaults to `cli`. Note this configuration is only available when using Pa11y on
 
 ### `rootElement` (element)
 
-The root element for testing a subset of the page opposed to the full document.
+The root element for testing a subset of the page opposed to the full document. 
 
 ```js
 pa11y('http://example.com/', {
     rootElement: '#main'
 });
 ```
-Defaults to `null`, meaning the full document will be tested.
+Defaults to `null`, meaning the full document will be tested. If the specified root element isn't found, the full document will be tested. 
 
 ### `rules` (array)
 


### PR DESCRIPTION
Adds a line to the README to clarify what happens if you try to test a root element that isn't there. 

Relates to https://stackoverflow.com/questions/50130152/accessibility-testing-using-pa11y-5-on-a-page-with-popup-overlay/50153618#50153618

It would be worth outputting a notice in the debug log if the root element isn't found. I might even open a PR for it later ;)