### PR TITLE
docs: fix function call for transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ If you wish to transform these results with the command-line reporters, then you
 // Assuming you've already run tests, and the results
 // are available in a `results` variable:
 const htmlReporter = require('pa11y/reporter/html');
-const html = htmlReporter.process(results, url);
+const html = htmlReporter.results(results, url);
 ```
 
 ### Async/Await


### PR DESCRIPTION
The html and tsv transformers have switched to using `results` as the function call, no longer `process`