### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Pa11y is your automated accessibility testing pal. It runs [HTML CodeSniffer][sn
 [![NPM version][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
 [![Build status][shield-build]][info-build]
-[![Dependencies][shield-dependencies]][info-dependencies]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 
 On the command line:
@@ -913,12 +912,10 @@ Copyright &copy; 2013–2017, Team Pa11y and contributors
 [sniff-issue]: https://github.com/squizlabs/HTML_CodeSniffer/issues/109
 [windows-install]: https://github.com/TooTallNate/node-gyp#installation
 
-[info-dependencies]: https://gemnasium.com/pa11y/pa11y
 [info-license]: LICENSE
 [info-node]: package.json
 [info-npm]: https://www.npmjs.com/package/pa11y
 [info-build]: https://travis-ci.org/pa11y/pa11y
-[shield-dependencies]: https://img.shields.io/gemnasium/pa11y/pa11y.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-node]: https://img.shields.io/badge/node.js%20support-8-brightgreen.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y.svg


### PR DESCRIPTION
Gemnasium has shut down. 

If we still want the services it provided, we can set it up on Gitlab instead 🙂 

Source: https://docs.gitlab.com/ee/user/project/import/gemnasium.html