### PR TITLE
Intercept first page requests only when necessary

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -114,42 +114,46 @@ async function runPa11yTest(url, options, state) {
 		state.autoClosePage = true;
 	}
 
-	// Intercept page requests, we need to do this in order
-	// to set the HTTP method or post data
-	await page.setRequestInterception(true);
+	// Until the `page.setRequestInterception` is buggy,
+	// use it only when necessary
+	if ((options.headers && Object.keys(options.headers).length) ||
+		(options.method && options.method.toLowerCase() !== 'get') ||
+		options.postData) {
 
-	// Intercept requests so we can set the HTTP method
-	// and post data. We only want to make changes to the
-	// first request that's handled, which is the request
-	// for the page we're testing
-	let interceptionHandled = false;
-	page.on('request', interceptedRequest => {
-		const overrides = {};
-		if (!interceptionHandled) {
+		// Intercept page requests, we need to do this in order
+		// to set the HTTP method or post data
+		await page.setRequestInterception(true);
 
-			// Override the request method
-			options.log.debug('Setting request method');
-			overrides.method = options.method;
+		// Intercept requests so we can set the HTTP method
+		// and post data. We only want to make changes to the
+		// first request that's handled, which is the request
+		// for the page we're testing
+		let interceptionHandled = false;
+		page.on('request', interceptedRequest => {
+			const overrides = {};
+			if (!interceptionHandled) {
 
-			// Override the request headers (and include the user-agent)
-			options.log.debug('Setting request headers');
-			overrides.headers = {
-				'user-agent': options.userAgent
-			};
-			for (const [key, value] of Object.entries(options.headers)) {
-				overrides.headers[key.toLowerCase()] = value;
+				// Override the request method
+				options.log.debug('Setting request method');
+				overrides.method = options.method;
+
+				// Override the request headers (and include the user-agent)
+				options.log.debug('Setting request headers');
+				for (const [key, value] of Object.entries(options.headers)) {
+					overrides.headers[key.toLowerCase()] = value;
+				}
+
+				// Override the request POST data if present
+				if (options.postData) {
+					options.log.debug('Setting request POST data');
+					overrides.postData = options.postData;
+				}
+
+				interceptionHandled = true;
 			}
-
-			// Override the request POST data if present
-			if (options.postData) {
-				options.log.debug('Setting request POST data');
-				overrides.postData = options.postData;
-			}
-
-			interceptionHandled = true;
-		}
-		interceptedRequest.continue(overrides);
-	});
+			interceptedRequest.continue(overrides);
+		});
+	}
 
 	// Listen for console logs on the page so that we can
 	// output them for debugging purposes
@@ -162,6 +166,11 @@ async function runPa11yTest(url, options, state) {
 
 	const gotoConfig = {waitUntil: 'networkidle2'};
 	gotoConfig.timeout = options.timeout;
+
+	if (options.userAgent) {
+		// Set the user agent
+		await page.setUserAgent(options.userAgent);
+	}
 
 	await page.goto(url, gotoConfig);
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -114,8 +114,10 @@ async function runPa11yTest(url, options, state) {
 		state.autoClosePage = true;
 	}
 
-	// Until the `page.setRequestInterception` is buggy,
-	// use it only when necessary
+	// Avoid to use `page.setRequestInterception` when not necessary
+	// because it occasionally stops page load:
+	// https://github.com/GoogleChrome/puppeteer/issues/3111
+	// https://github.com/GoogleChrome/puppeteer/issues/3121
 	if ((options.headers && Object.keys(options.headers).length) ||
 		(options.method && options.method.toLowerCase() !== 'get') ||
 		options.postData) {

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -139,6 +139,7 @@ async function runPa11yTest(url, options, state) {
 
 				// Override the request headers (and include the user-agent)
 				options.log.debug('Setting request headers');
+				overrides.headers = {};
 				for (const [key, value] of Object.entries(options.headers)) {
 					overrides.headers[key.toLowerCase()] = value;
 				}

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -96,50 +96,9 @@ describe('lib/pa11y', () => {
 			assert.calledWithExactly(puppeteer.mockBrowser.newPage);
 		});
 
-		it('enables request interception', () => {
-			assert.calledOnce(puppeteer.mockPage.setRequestInterception);
-			assert.calledWithExactly(puppeteer.mockPage.setRequestInterception, true);
-		});
-
-		it('adds a request handler to the page', () => {
-			assert.called(puppeteer.mockPage.on);
-			assert.calledWith(puppeteer.mockPage.on, 'request');
-			assert.isFunction(puppeteer.mockPage.on.withArgs('request').firstCall.args[1]);
-		});
-
-		describe('request handler', () => {
-			let mockInterceptedRequest;
-
-			beforeEach(() => {
-				mockInterceptedRequest = {
-					continue: sinon.stub()
-				};
-				puppeteer.mockPage.on.withArgs('request').firstCall.args[1](mockInterceptedRequest);
-			});
-
-			it('calls `interceptedRequest.continue` with the method option', () => {
-				assert.calledOnce(mockInterceptedRequest.continue);
-				assert.calledWith(mockInterceptedRequest.continue, {
-					method: pa11y.defaults.method,
-					headers: {
-						'user-agent': pa11y.defaults.userAgent
-					}
-				});
-			});
-
-			describe('when called a second time', () => {
-
-				beforeEach(() => {
-					puppeteer.mockPage.on.withArgs('request').firstCall.args[1](mockInterceptedRequest);
-				});
-
-				it('calls `interceptedRequest.continue` with an empty object', () => {
-					assert.calledTwice(mockInterceptedRequest.continue);
-					assert.deepEqual(mockInterceptedRequest.continue.secondCall.args[0], {});
-				});
-
-			});
-
+		it('set the user agent', () => {
+			assert.calledOnce(puppeteer.mockPage.setUserAgent);
+			assert.calledWithExactly(puppeteer.mockPage.setUserAgent, pa11y.defaults.userAgent);
 		});
 
 		it('adds a console handler to the page', () => {
@@ -463,6 +422,17 @@ describe('lib/pa11y', () => {
 				await pa11y(options);
 			});
 
+			it('enables request interception', () => {
+				assert.calledOnce(puppeteer.mockPage.setRequestInterception);
+				assert.calledWithExactly(puppeteer.mockPage.setRequestInterception, true);
+			});
+
+			it('adds a request handler to the page', () => {
+				assert.called(puppeteer.mockPage.on);
+				assert.calledWith(puppeteer.mockPage.on, 'request');
+				assert.isFunction(puppeteer.mockPage.on.withArgs('request').firstCall.args[1]);
+			});
+
 			describe('request handler', () => {
 				let mockInterceptedRequest;
 
@@ -478,9 +448,7 @@ describe('lib/pa11y', () => {
 					assert.calledWith(mockInterceptedRequest.continue, {
 						method: options.method,
 						postData: options.postData,
-						headers: {
-							'user-agent': pa11y.defaults.userAgent
-						}
+						headers: {}
 					});
 				});
 
@@ -553,8 +521,7 @@ describe('lib/pa11y', () => {
 						headers: {
 							foo: 'bar',
 							bar: 'baz',
-							'foo-bar-baz': 'qux',
-							'user-agent': pa11y.defaults.userAgent
+							'foo-bar-baz': 'qux'
 						}
 					});
 				});


### PR DESCRIPTION
Since the `page.setRequestInterception` method of puppeteer's Page is buggy (there are some relevant issues [here](https://github.com/GoogleChrome/puppeteer/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+setRequestInterception)), I think it is better avoid to use it until it is necessary (eg for POST page requests).

In our case, intercepting requests totally breaks the page :(