### PR TITLE
Clarify the screen capture option

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ pa11y('http://example.com/', {
 });
 ```
 
-Defaults to `null`, meaning the screen will not be captured.
+Defaults to `null`, meaning the screen will not be captured. Note the directory part of this path must be an existing directory in the file system – Pa11y will not create this for you.
 
 ### `standard` (string)
 


### PR DESCRIPTION
The directory in the screen capture path must exist for a
screen capture to be saved. This is Puppeteer behaviour,
but we weren't documenting anywhere