### PR TITLE
Remove spaces from being part of a wait actions value (#396)

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -155,7 +155,7 @@ module.exports.actions = [
 	// E.g. "wait for url to be https://example.com/"
 	{
 		name: 'wait-for-url',
-		match: /^wait for (fragment|hash|host|path|url)( to (not )?be)? (.+)$/i,
+		match: /^wait for (fragment|hash|host|path|url)( to (not )?be)? ([^\s]+)$/i,
 		run: async (browser, page, options, matches) => {
 			const expectedValue = matches[4];
 			const negated = (matches[3] !== undefined);

--- a/test/unit/lib/action.test.js
+++ b/test/unit/lib/action.test.js
@@ -794,6 +794,13 @@ describe('lib/action', () => {
 					'not ',
 					'example.com'
 				]);
+				assert.notDeepEqual('wait for path not to be /account/signin/'.match(action.match), [
+					'wait for path not to be /account/signin/',
+					'path',
+					undefined,
+					undefined,
+					'not to be /account/signin/'
+				]);
 			});
 
 		});


### PR DESCRIPTION
This is a fix for #396 

The reason for the problem is the value part of the regex (`(.+)`) matches anything. However fragment, hash, host, path or url can contain spaces.

Thus `([^\s]+)` can happily grab that without greedily ignoring spaces.