### PR TITLE
docs: update the badge URL for the Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,6 @@ Copyright &copy; 2013–2019, Team Pa11y and contributors
 [info-npm]: https://www.npmjs.com/package/pa11y
 [info-build]: https://travis-ci.org/pa11y/pa11y
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
-[shield-node]: https://img.shields.io/badge/node.js%20support-8-brightgreen.svg
+[shield-node]: https://img.shields.io/node/v/pa11y.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y.svg
 [shield-build]: https://img.shields.io/travis/pa11y/pa11y/master.svg


### PR DESCRIPTION
Uses the dynamic URL that looks up the supported Node.js versions on npm.

Resolves https://github.com/pa11y/pa11y/issues/470.