### PR TITLE
Add missing tests

### DIFF
--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -691,6 +691,7 @@ describe('lib/pa11y', () => {
 				puppeteer.mockPage.close.resetHistory();
 				options.browser = puppeteer.mockBrowser;
 				options.page = puppeteer.mockPage;
+
 				await pa11y(options);
 			});
 
@@ -732,6 +733,27 @@ describe('lib/pa11y', () => {
 
 			});
 
+		});
+
+		describe('when `options.page` and `options.ignoreUrl` are set', () => {
+
+			beforeEach(async () => {
+				extend.resetHistory();
+				puppeteer.launch.resetHistory();
+				puppeteer.mockBrowser.newPage.resetHistory();
+				puppeteer.mockBrowser.close.resetHistory();
+				puppeteer.mockPage.close.resetHistory();
+				puppeteer.mockPage.goto.resetHistory();
+				options.browser = puppeteer.mockBrowser;
+				options.page = puppeteer.mockPage;
+				options.ignoreUrl = true;
+
+				await pa11y(options);
+			});
+
+			it('does not call page.goto', () => {
+				assert.notCalled(options.page.goto);
+			});
 		});
 
 		describe('when `options.page` is set without `options.browser`', () => {

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -483,6 +483,21 @@ describe('lib/pa11y', () => {
 					});
 				});
 
+				describe('when triggered again', () => {
+					beforeEach(() => {
+						puppeteer.mockPage.on.withArgs('request').firstCall.args[1](mockInterceptedRequest);
+					});
+
+					it('calls `interceptedRequest.continue` with an empty object', () => {
+						assert.calledTwice(mockInterceptedRequest.continue);
+						assert.calledWith(mockInterceptedRequest.continue, {
+							method: options.method,
+							postData: options.postData,
+							headers: {}
+						});
+						assert.calledWith(mockInterceptedRequest.continue, {});
+					});
+				});
 			});
 
 		});
@@ -654,7 +669,8 @@ describe('lib/pa11y', () => {
 					puppeteer.mockPage.goto.rejects(headlessChromeError);
 					try {
 						await pa11y(options);
-					} catch (error) {}
+					} catch (error) {
+					}
 				});
 
 				it('does not close the browser', () => {
@@ -702,7 +718,8 @@ describe('lib/pa11y', () => {
 					puppeteer.mockPage.goto.rejects(headlessChromeError);
 					try {
 						await pa11y(options);
-					} catch (error) {}
+					} catch (error) {
+					}
 				});
 
 				it('does not close the browser', () => {

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -561,6 +561,20 @@ describe('lib/pa11y', () => {
 
 		});
 
+		describe('when `options.userAgent` is `false`', () => {
+
+			beforeEach(async () => {
+				puppeteer.mockPage.setUserAgent.resetHistory();
+				options.userAgent = false;
+				await pa11y(options);
+			});
+
+			it('automatically ignores warnings', () => {
+				assert.notCalled(puppeteer.mockPage.setUserAgent);
+			});
+
+		});
+
 		describe('when `options.actions` is set', () => {
 
 			beforeEach(async () => {
@@ -783,7 +797,6 @@ describe('lib/pa11y', () => {
 				assert.match(puppeteer.mockPage.evaluate.getCall(1).args[0], /^\s*;\s*mock-runner-pa11y-node-module-js\s*;\s*;\s*window\.__pa11y\.runners\['pa11y-node-module'\] = \(\) => 'mock-runner-pa11y-node-module'\s*;\s*$/);
 				assert.match(puppeteer.mockPage.evaluate.getCall(2).args[0], /^\s*;\s*mock-runner-node-module-js\s*;\s*;\s*window\.__pa11y\.runners\['node-module'\] = \(\) => 'mock-runner-node-module'\s*;\s*$/);
 			});
-
 		});
 
 		describe('when `options.runners` is set and one of the runners does not support the current version of Pa11y', () => {


### PR DESCRIPTION
Adds three new tests to fill some missing branches. Results in 100% code coverage 💃 

The tests added are all checks that an action is **not** taken
- `setUserAgent` isn't called if no user agent is passed
- The interception handler only triggers on the first intercepted request (the main HTTP GET)
- Doesn't navigate the puppeteer page if `ignoreUrl` is true