### PR TITLE
Invert the order of setViewport and goto

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -99,14 +99,12 @@ async function runPa11yTest(url, options, state) {
 		browser = state.browser = options.browser;
 		state.autoClose = false;
 	} else {
-
 		// Launch a Headless Chrome browser. We use a
 		// state object which is accessible from the
 		// wrapping function
 		options.log.debug('Launching Headless Chrome');
 		browser = state.browser = await puppeteer.launch(options.chromeLaunchConfig);
 		state.autoClose = true;
-
 	}
 
 	if (options.browser && options.page) {
@@ -167,7 +165,6 @@ async function runPa11yTest(url, options, state) {
 		options.log.debug(`Browser Console: ${message.text()}`);
 	});
 
-	// Navigate to the URL we're going to test
 	options.log.debug('Opening URL in Headless Chrome');
 
 	const gotoConfig = {waitUntil: 'networkidle2'};
@@ -178,12 +175,13 @@ async function runPa11yTest(url, options, state) {
 		await page.setUserAgent(options.userAgent);
 	}
 
+	// Resize the viewport
+	await page.setViewport(options.viewport);
+
+	// Navigate to the URL we're going to test
 	if (!options.ignoreUrl) {
 		await page.goto(url, gotoConfig);
 	}
-
-	// Resize the viewport
-	await page.setViewport(options.viewport);
 
 	// Run actions
 	if (options.actions.length) {
@@ -338,6 +336,7 @@ function loadRunnerFile(runner) {
  * @param {String} runnerSupportString - The runner support string (a semver range).
  * @param {String} pa11yVersion - The version of Pa11y to test support for.
  * @throws {Error} Throws an error if the reporter does not support the given version of Pa11y
+ * @returns {void}
  */
 function assertReporterCompatibility(runnerName, runnerSupportString, pa11yVersion) {
 	if (!runnerSupportString || !semver.satisfies(pa11yVersion, runnerSupportString)) {


### PR DESCRIPTION
From the [puppeteer docs about setViewport](https://github.com/GoogleChrome/puppeteer/blob/387a53270762cd1a3e7db1c156275231655b1b10/docs/api.md#pagesetviewportviewport):

> In certain cases, setting viewport will reload the page in order to set the isMobile or hasTouch properties.
> A lot of websites don't expect phones to change size, so you should set the viewport before navigating to the page.

This hasn't caused any problems that we know of, but we probably want to avoid this behaviour.