### PR TITLE
Adds sanity checks against real sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "html_codesniffer": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.4.0.tgz",
-      "integrity": "sha512-4LU3IaTLS7hMhueYE6a6G+QuwFkIA9S+V9KCXttnJ9YnJ/Kpl+L7R7aH+nohw1jaf0KjaHqQ7Y2uXgsWNIIxQA=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.4.1.tgz",
+      "integrity": "sha512-7g4Z8+7agJFi7XJGu2r0onIqA7ig9b26vFEvUE6DgtFJlJzy1ELYEKzzd5Xwam4xjHiHQ/w8yHO7KTGNcXnwzg=="
     },
     "https-proxy-agent": {
       "version": "2.2.2",
@@ -2612,11 +2612,11 @@
       }
     },
     "pa11y-runner-htmlcs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pa11y-runner-htmlcs/-/pa11y-runner-htmlcs-1.1.0.tgz",
-      "integrity": "sha512-lyP4AOTzXjjBSy8oNUj5552rxLvT/Ln4YR5Ph9ZYNI2fItJa34T5SLbB35SqhAUBlEQg1UyBsvWcAWfX528SsQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pa11y-runner-htmlcs/-/pa11y-runner-htmlcs-1.2.0.tgz",
+      "integrity": "sha512-uf0wEsoeRfyALXVcZeDadV7ot7pE6JZ3EZwbspwmyXW30ahjCClAfE/FtaNo1y2Mlxx5J9ui1sW2YzhHXocV5g==",
       "requires": {
-        "html_codesniffer": "^2.4.0"
+        "html_codesniffer": "^2.4.1"
       }
     },
     "parent-module": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pa11y-reporter-csv": "^1.0.0",
     "pa11y-reporter-json": "^1.0.0",
     "pa11y-runner-axe": "^1.0.1",
-    "pa11y-runner-htmlcs": "^1.1.0",
+    "pa11y-runner-htmlcs": "^1.2.0",
     "puppeteer": "^1.13.0",
     "semver": "^5.6.0"
   },

--- a/test/integration/sanity-check-real-sites.test.js
+++ b/test/integration/sanity-check-real-sites.test.js
@@ -1,0 +1,34 @@
+const assert = require('proclaim');
+const pa11y = require('../../lib/pa11y');
+
+async function runTest(url) {
+	try {
+		const result = await pa11y(url);
+		assert.isObject(result);
+	} catch (error) {
+		assert.fail(`Expected no error but got "${error.message}"`);
+	}
+}
+
+describe('sanity checks', () => {
+
+	it('runs on https://www.nature.com/', async () => {
+		await runTest('https://www.nature.com/');
+	}).timeout(10000);
+
+	it('runs on https://google.com/', async () => {
+		await runTest('https://www.nature.com/');
+	}).timeout(10000);
+
+	it('runs on http://culturaestero.regione.emilia-romagna.it/it', async () => {
+		await runTest('http://culturaestero.regione.emilia-romagna.it/it');
+	}).timeout(10000);
+
+	it('runs on https://www.dundee.ac.uk', async () => {
+		await runTest('https://www.dundee.ac.uk');
+	}).timeout(10000);
+
+	it('runs on https://link.springer.com', async () => {
+		await runTest('https://link.springer.com');
+	}).timeout(10000);
+});

--- a/test/integration/sanity-check-real-sites.test.js
+++ b/test/integration/sanity-check-real-sites.test.js
@@ -1,38 +1,35 @@
 const assert = require('proclaim');
 const pa11y = require('../../lib/pa11y');
 
+const TIMEOUT = 15000;
+
 async function runTest(url) {
 	try {
 		const result = await pa11y(url);
 		assert.isObject(result);
 	} catch (error) {
-		assert.fail(`Expected no error but got "${error.message}"`);
+		assert.fail(`Expected no error but pa11y threw an exception with message: "${error.message}"`);
 	}
 }
 
-describe('sanity checks', () => {
-
+describe('Pa11y runs without failure', () => {
 	it('runs on https://www.nature.com/', async () => {
 		await runTest('https://www.nature.com/');
-	}).timeout(10000);
+	}).timeout(TIMEOUT);
 
 	it('runs on https://google.com/', async () => {
 		await runTest('https://www.nature.com/');
-	}).timeout(10000);
-
-	it('runs on http://culturaestero.regione.emilia-romagna.it/it', async () => {
-		await runTest('http://culturaestero.regione.emilia-romagna.it/it');
-	}).timeout(10000);
+	}).timeout(TIMEOUT);
 
 	it('runs on https://www.dundee.ac.uk', async () => {
 		await runTest('https://www.dundee.ac.uk');
-	}).timeout(10000);
+	}).timeout(TIMEOUT);
 
 	it('runs on https://link.springer.com', async () => {
 		await runTest('https://link.springer.com');
-	}).timeout(10000);
+	}).timeout(TIMEOUT);
 
 	it('runs on https://www.bbc.co.uk', async () => {
 		await runTest('https://www.bbc.co.uk');
-	}).timeout(10000);
+	}).timeout(TIMEOUT);
 });

--- a/test/integration/sanity-check-real-sites.test.js
+++ b/test/integration/sanity-check-real-sites.test.js
@@ -31,4 +31,8 @@ describe('sanity checks', () => {
 	it('runs on https://link.springer.com', async () => {
 		await runTest('https://link.springer.com');
 	}).timeout(10000);
+
+	it('runs on https://www.bbc.co.uk', async () => {
+		await runTest('https://www.bbc.co.uk');
+	}).timeout(10000);
 });


### PR DESCRIPTION
We've had problems recently with new versions of pa11y breaking on some sites (cough cough AMD).

This is a small set of integration tests that ensure pa11y will run without throwing an exception against a set of sites, some of which we know have caused isues.
