### PR TITLE
WIP: Add lower-level runner API to support non-browser runners

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -367,10 +367,18 @@ async function runPa11yWithOptions(options, state) {
 		return window.__pa11y.initialize(runOptions);
 	}, serializableOptions);
 
+	// Execute all of the runners and process issues
 	for (const runner of options.runners) {
-		const runnerIssues = await state.page.evaluate((runOptions, runnerName) => {
-			return window.__pa11y.run(runOptions, runnerName);
-		}, serializableOptions, runner);
+		const runnerModule = loadRunnerFile(runner);
+		let runnerIssues;
+
+		if (runnerModule.processPage) {
+			runnerIssues = await runnerModule.processPage(state.page, serializableOptions);
+		} else {
+			runnerIssues = await state.page.evaluate((runOptions, runnerName) => {
+				return window.__pa11y.run(runOptions, runnerName);
+			}, serializableOptions, runner);
+		}
 
 		runnerIssues.map(issue => {
 			issue.runner = runner;

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -350,11 +350,9 @@ async function injectRunners(options, state) {
  *   this function.
  * @returns {Promise} A promise which resolves with the results of the pa11y evaluation
  */
-function runPa11yWithOptions(options, state) {
+async function runPa11yWithOptions(options, state) {
 	/* eslint-disable no-underscore-dangle */
-	return state.page.evaluate(runOptions => {
-		return window.__pa11y.run(runOptions);
-	}, {
+	const serializableOptions = {
 		hideElements: options.hideElements,
 		ignore: options.ignore,
 		pa11yVersion: pkg.version,
@@ -363,7 +361,25 @@ function runPa11yWithOptions(options, state) {
 		runners: options.runners,
 		standard: options.standard,
 		wait: options.wait
-	});
+	};
+
+	const result = await state.page.evaluate(runOptions => {
+		return window.__pa11y.initialize(runOptions);
+	}, serializableOptions);
+
+	for (const runner of options.runners) {
+		const runnerIssues = await state.page.evaluate((runOptions, runnerName) => {
+			return window.__pa11y.run(runOptions, runnerName);
+		}, serializableOptions, runner);
+
+		runnerIssues.map(issue => {
+			issue.runner = runner;
+			return issue;
+		});
+		result.issues = result.issues.concat(runnerIssues);
+	}
+
+	return result;
 	/* eslint-enable no-underscore-dangle */
 }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,6 +8,7 @@
 	const pa11y = exports.__pa11y = {
 		getElementContext,
 		getElementSelector,
+		initialize: initializePa11y,
 		run: runPa11y,
 		runners: {}
 	};
@@ -25,36 +26,33 @@
 	};
 
 	/**
-	 * Run Pa11y on the current page.
-	 * @public
-	 * @param {Object} options - Options to use when running tests.
-	 * @returns {Promise} Returns a promise which resolves with test results.
+	 *
+	 * @param {*} options
 	 */
-	async function runPa11y(options) {
+	async function initializePa11y(options) {
 		pa11y.version = options.pa11yVersion;
 
 		await wait(options.wait);
 
 		// Set up the result object
-		const result = {
+		return {
 			documentTitle: window.document.title || '',
 			pageUrl: window.location.href || '',
 			issues: []
 		};
+	}
 
-		// Execute all of the runners and process issues
-		for (const runner of options.runners) {
-			const runnerIssues = await pa11y.runners[runner](options, pa11y);
-			runnerIssues.map(issue => {
-				issue.runner = runner;
-				return issue;
-			});
-			result.issues = result.issues.concat(runnerIssues);
-		}
-		result.issues = processIssues(result.issues);
+	/**
+	 * Run Pa11y on the current page.
+	 * @public
+	 * @param {Object} options - Options to use when running tests.
+	 * @returns {Promise} Returns a promise which resolves with test results.
+	 */
+	async function runPa11y(options, runnerName) {
+		const runnerIssues = await pa11y.runners[runnerName](options, pa11y);
 
 		// Return the result object
-		return result;
+		return processIssues(runnerIssues);
 
 		/**
 		 * Process issues from a runner.


### PR DESCRIPTION
Initially [discussed on Slack](https://pa11y.slack.com/archives/C16MP57QT/p1589189298025500). Currently just a draft PR with lots of missing parts.

Pa11y supports custom runners, but those runners are only executed within the context of the browser (with Puppeteer’s [`page.evaluate`](https://pptr.dev/#?product=Puppeteer&version=v3.1.0&show=api-pageevaluatepagefunction-args)). I would like to make runners that rely on "server-side" processing, either Node modules that cannot run in the browser, or CLI tools from other languages that can only be integrated with Node code.

This PR reworks the runners’ integration to introduce a new lower-level API that supports the scenario described above, as well as making it possible for runners to manipulate the Puppeteer page if they want to – e.g. to read the [page’s accessibility tree](https://pptr.dev/#?product=Puppeteer&version=v3.1.0&show=api-class-accessibility), or see if the page has horizontal scrolling on smaller viewport sizes.

---

This implementation does two things:

- Moves the logic of executing individual runners and collating their issues from the browser context to Node. This change alone should be completely backwards-compatible and not impact Pa11y’s behavior.
- Introduces a new "`processPage`" method for runners, which is invoked instead of `run` when present, and gives runners access to the Puppeteer page, expecting an array of issues back.

I’m not particularly convinced this is the best abstraction / API, but it’s the one that was the least work to get experimenting with.

There are a few things I haven’t touched yet and would likely need to address in some way:

- `loadRunnerScript` still executes even if the runner has no `scripts` nor `run` method.
  - Because of this, the runner still needs to have an empty `scripts: []`, and `run: () => {}`.
  - `assertReporterCompatibility` only runs within `loadRunnerScript`. If `loadRunnerScript` is changed, that compatibility check would need to be done elsewhere.
- All of the issue filtering logic is still in the Pa11y browser runner context only, and it’s unclear how compatible it would be with runners that aren’t in the browser,
  - Retrieving the `context` and `selector` as Pa11y does relies on the runner providing a DOM element.
  - The `ignore` by code only works for runners that have codes :)
  - The `rootElement` filtering depends on the DOM
  - `hideElements` also depends on the DOM

---

To try this out, here are install instructions with the runner I’m currently working on based on the [v.Nu HTML validator](https://validator.github.io/validator/):

```sh
# On macOS,
brew install vnu
# Elsewhere, grab the latest release from
# https://github.com/validator/validator/releases/latest.
# Make sure the `vnu` executable is in your PATH.
# Then,
npm install -g https://github.com/thibaudcolas/pa11y#feature/node-runners pa11y-runner-vnu

pa11y --runner vnu https://www.example.com/
```

<details>

<summary>Output</summary>

```txt
$ pa11y --runner vnu https://www.example.com/

Welcome to Pa11y

 > Running Pa11y on URL https://www.example.com/

Results for URL: https://www.example.com/

 • Error: A document must not include both a “meta” element with an “http-equiv” attribute whose value is “content-type”, and a “meta” element with a “charset” attribute.
   ├── html-validation
   ├──
   └── f-8"> <meta http-equiv="Content-type" content="text/html; charset=utf-8"> <

 • Notice:  The “type” attribute for the “style” element is not needed and should be omitted.
   ├── html-validation
   ├──
   └── e=1"> <style type="text/css"> b

 • Notice: Consider adding a “lang” attribute to the “html” start tag to declare the language of this document.
   ├── html-validation
   ├──
   └── TYPE html><html><head>

1 Errors
2 Notices
```

</details>

Here is the source of that runner: [pa11y-runner-vnu](https://github.com/thibaudcolas/pa11y-runner-vnu), and extra install instructions. If you don’t want to install `vnu`, here is a much simpler dummy runner you can try this with:

```js
module.exports = {
  // Update this when an API-compatible Pa11y gets released.
  supports: "^6.0.0-alpha || ^6.0.0-beta",
  // Needs to be defined even if this runner does not rely on any scripts.
  scripts: [],
  // needs to be defined even though it’s empty.
  run: () => {},
  processPage: async (page) => {
    const html = await page.content();

    if (!html.includes("<html lang=")) {
      return [
        {
          code: "html-has-lang",
          message: "<html> elements must have a `lang` attribute",
          type: "error",
          context: "",
          selector: "",
        },
      ];
    }

    return [];
  },
};
```