### PR TITLE
Replace puppeteer with playwright

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -87,7 +87,10 @@ module.exports.actions = [
 			const selector = matches[2];
 			const value = matches[3];
 			try {
-				await page.evaluate((targetSelector, desiredValue) => {
+				await page.evaluate(({
+					targetSelector,
+					desiredValue
+				}) => {
 					const target = document.querySelector(targetSelector);
 					if (!target) {
 						return Promise.reject(new Error('No element found'));
@@ -104,7 +107,10 @@ module.exports.actions = [
 						bubbles: true
 					}));
 					return Promise.resolve();
-				}, selector, value);
+				}, {
+					targetSelector: selector,
+					desiredValue: value
+				});
 			} catch (error) {
 				throw new Error(`Failed action: no element matching selector "${selector}"`);
 			}
@@ -121,7 +127,10 @@ module.exports.actions = [
 			const checked = (matches[1] !== 'uncheck');
 			const selector = matches[3];
 			try {
-				await page.evaluate((targetSelector, isChecked) => {
+				await page.evaluate(({
+					targetSelector,
+					isChecked
+				}) => {
 					const target = document.querySelector(targetSelector);
 					if (!target) {
 						return Promise.reject(new Error('No element found'));
@@ -131,7 +140,10 @@ module.exports.actions = [
 						bubbles: true
 					}));
 					return Promise.resolve();
-				}, selector, checked);
+				}, {
+					targetSelector: selector,
+					isChecked: checked
+				});
 			} catch (error) {
 				throw new Error(`Failed action: no element matching selector "${selector}"`);
 			}
@@ -182,7 +194,11 @@ module.exports.actions = [
 			}
 
 
-			function locationHasProperty(locationProperty, value, isNegated) {
+			function locationHasProperty({
+				locationProperty,
+				value,
+				isNegated
+			}) {
 				return isNegated ?
 					window.location[locationProperty] !== value :
 					window.location[locationProperty] === value;
@@ -190,10 +206,11 @@ module.exports.actions = [
 
 			await page.waitForFunction(
 				locationHasProperty,
-				{},
-				property,
-				expectedValue,
-				negated
+				{
+					locationProperty: property,
+					value: expectedValue,
+					isNegated: negated
+				}
 			);
 		}
 	},
@@ -208,7 +225,10 @@ module.exports.actions = [
 			const selector = matches[2];
 			const state = matches[4];
 
-			await page.waitForFunction((targetSelector, desiredState) => {
+			await page.waitForFunction(({
+				targetSelector,
+				desiredState
+			}) => {
 				const targetElement = document.querySelector(targetSelector);
 
 				const statusChecks = {
@@ -244,8 +264,12 @@ module.exports.actions = [
 
 				return isInDesiredVisibilityState;
 			}, {
+				targetSelector: selector,
+				desiredState: state
+			},
+			{
 				polling: 200
-			}, selector, state);
+			});
 		}
 	},
 
@@ -260,30 +284,32 @@ module.exports.actions = [
 			const eventType = matches[3];
 			try {
 				/* eslint-disable no-underscore-dangle */
-				await page.evaluate(
-					(targetSelector, desiredEvent) => {
-						const target = document.querySelector(targetSelector);
-						if (!target) {
-							return Promise.reject(
-								new Error('No element found')
-							);
-						}
-						target.addEventListener(desiredEvent, () => {
-							window._pa11yWaitForElementEventFired = true;
-						}, {
-							once: true
-						});
-					},
-					selector,
-					eventType
-				);
+				await page.evaluate(({
+					targetSelector,
+					desiredEvent
+				}) => {
+					const target = document.querySelector(targetSelector);
+					if (!target) {
+						return Promise.reject(
+							new Error('No element found')
+						);
+					}
+					target.addEventListener(desiredEvent, () => {
+						window._pa11yWaitForElementEventFired = true;
+					}, {
+						once: true
+					});
+				}, {
+					targetSelector: selector,
+					desiredEvent: eventType
+				});
 				await page.waitForFunction(() => {
 					if (window._pa11yWaitForElementEventFired) {
 						delete window._pa11yWaitForElementEventFired;
 						return true;
 					}
 					return false;
-				}, {
+				}, null, {
 					polling: 200
 				});
 				/* eslint-enable no-underscore-dangle */

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -7,7 +7,7 @@ const path = require('path');
 const {promisify} = require('util');
 const pkg = require('../package.json');
 const promiseTimeout = require('p-timeout');
-const puppeteer = require('puppeteer');
+const {chromium: playwright} = require('playwright');
 const semver = require('semver');
 
 const runnerJavascriptPromises = {};
@@ -49,7 +49,7 @@ async function pa11y(url, options = {}, callback) {
 			throw error;
 		}
 	} finally {
-		await stateCleanup(state);
+		await stateCleanup(options, state);
 	}
 	// Run callback if present, and resolve with pa11yResults
 	return callback ? callback(pa11yError, pa11yResults) : pa11yResults;
@@ -143,15 +143,20 @@ async function runPa11yTest(url, options, state) {
 /**
  * Ensures that puppeteer resources are freed and listeners removed.
  * @private
+ * @param {Object} options - Options to change the way tests run.
  * @param {Object} state - The last-known state of the test-run.
  * @returns {Promise} A promise which resolves when resources are released
  */
-async function stateCleanup(state) {
+async function stateCleanup(options, state) {
 	if (state.browser && state.autoClose) {
 		await state.browser.close();
 	} else if (state.page) {
-		state.page.removeListener('request', state.requestInterceptCallback);
-		state.page.removeListener('console', state.consoleCallback);
+		try {
+			state.page.removeListener('request', state.requestInterceptCallback);
+			state.page.removeListener('console', state.consoleCallback);
+		} catch (error) {
+			options.log.debug(error);
+		}
 		if (state.autoClosePage) {
 			await state.page.close();
 		}
@@ -179,7 +184,7 @@ async function setBrowser(options, state) {
 		// state object which is accessible from the
 		// wrapping function
 		options.log.debug('Launching Headless Chrome');
-		state.browser = await puppeteer.launch(
+		state.browser = await playwright.launch(
 			options.chromeLaunchConfig
 		);
 		state.autoClose = true;
@@ -199,7 +204,11 @@ async function setPage(options, state) {
 		state.page = options.page;
 		state.autoClosePage = false;
 	} else {
-		state.page = await state.browser.newPage();
+		state.page = await state.browser.newPage({
+			viewport: options.viewport,
+			userAgent: options.userAgent
+		});
+		state.page.setDefaultTimeout(5000);
 		state.autoClosePage = true;
 	}
 	// Listen for console logs on the page so that we can
@@ -209,10 +218,6 @@ async function setPage(options, state) {
 	};
 	state.page.on('console', state.consoleCallback);
 	options.log.debug('Opening URL in Headless Chrome');
-	if (options.userAgent) {
-		await state.page.setUserAgent(options.userAgent);
-	}
-	await state.page.setViewport(options.viewport);
 }
 
 /**
@@ -237,9 +242,6 @@ async function interceptRequests(options, state) {
 	if (!shouldInterceptRequests) {
 		return;
 	}
-	// Intercept page requests, we need to do this in order
-	// to set the HTTP method or post data
-	await state.page.setRequestInterception(true);
 
 	// Intercept requests so we can set the HTTP method
 	// and post data. We only want to make changes to the
@@ -270,7 +272,10 @@ async function interceptRequests(options, state) {
 		}
 		interceptedRequest.continue(overrides);
 	};
-	state.page.on('request', state.requestInterceptCallback);
+
+	// Intercept page requests, we need to do this in order
+	// to set the HTTP method or post data
+	await state.page.route('**/*', state.requestInterceptCallback);
 }
 
 /**
@@ -286,7 +291,7 @@ async function gotoUrl(url, options, state) {
 	// Navigate to the URL we're going to test
 	if (!options.ignoreUrl) {
 		await state.page.goto(url, {
-			waitUntil: 'networkidle2',
+			waitUntil: 'networkidle',
 			timeout: options.timeout
 		});
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,10 +332,20 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/mime-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
+    "@types/node": {
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz",
+      "integrity": "sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ==",
+      "optional": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "acorn": {
       "version": "7.1.0",
@@ -350,9 +360,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -458,11 +471,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
     "axe-core": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
@@ -519,10 +527,10 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -674,17 +682,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -693,11 +690,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -770,6 +762,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "envinfo": {
       "version": "7.5.0",
@@ -964,29 +964,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
       }
     },
     "fast-deep-equal": {
@@ -1008,9 +993,9 @@
       "dev": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -1188,6 +1173,14 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -1219,8 +1212,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -1281,11 +1273,11 @@
       "integrity": "sha512-vcz0yAaX/OaV6sdNHuT9alBOKkSxYb8h5Yq26dUqgi7XmCgGUSa7U9PiY1PBXQFMjKv1wVPs5/QzHlGuxPDUGg=="
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -1468,11 +1460,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1641,6 +1628,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jpeg-js": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1774,22 +1766,9 @@
       }
     },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-    },
-    "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
-    },
-    "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "requires": {
-        "mime-db": "1.43.0"
-      }
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -1808,12 +1787,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -2448,16 +2429,44 @@
         }
       }
     },
+    "playwright": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.5.1.tgz",
+      "integrity": "sha512-FYxrQ2TAmvp5ZnBnc6EJHc1Vt3DmXx8xVDq6rxVVG4YVoNKHYMarHI92zGyDlueN2kKCavrhk4Et9w6jJ5XWaA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -2482,47 +2491,35 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
+    "proper-lockfile": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+      "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-      "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
-      "requires": {
-        "@types/mime-types": "^2.1.0",
-        "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
-        "mime-types": "^2.1.25",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -2585,10 +2582,16 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2614,7 +2617,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2651,8 +2655,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "9.0.2",
@@ -2821,14 +2824,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2983,11 +2978,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -3005,11 +2995,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-inspect": {
       "version": "0.1.8",
@@ -3178,12 +3163,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "y18n": {
       "version": "4.0.0",
@@ -3256,11 +3238,12 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pa11y-reporter-json": "^2.0.0",
     "pa11y-runner-axe": "^2.0.0",
     "pa11y-runner-htmlcs": "^2.0.0",
-    "puppeteer": "^2.1.1",
+    "playwright": "^1.5.1",
     "semver": "^5.7.1"
   },
   "devDependencies": {

--- a/test/unit/mock/playwright.mock.js
+++ b/test/unit/mock/playwright.mock.js
@@ -2,16 +2,16 @@
 
 const sinon = require('sinon');
 
-const puppeteer = module.exports = {
+const playwright = module.exports = {
 	launch: sinon.stub()
 };
 
-const mockBrowser = puppeteer.mockBrowser = {
+const mockBrowser = playwright.mockBrowser = {
 	close: sinon.stub(),
 	newPage: sinon.stub()
 };
 
-const mockPage = (puppeteer.mockPage = {
+const mockPage = (playwright.mockPage = {
 	addScriptTag: sinon.stub().resolves(),
 	close: sinon.stub().resolves(),
 	click: sinon.stub().resolves(),
@@ -20,14 +20,14 @@ const mockPage = (puppeteer.mockPage = {
 	goto: sinon.stub().resolves(),
 	on: sinon.stub(),
 	removeListener: sinon.stub(),
+	route: sinon.stub().resolves(),
 	screenshot: sinon.stub().resolves(),
+	setDefaultTimeout: sinon.stub(),
 	setExtraHTTPHeaders: sinon.stub().resolves(),
 	setRequestInterception: sinon.stub().resolves(),
-	setUserAgent: sinon.stub().resolves(),
-	setViewport: sinon.stub().resolves(),
 	type: sinon.stub().resolves(),
 	waitForFunction: sinon.stub().resolves()
 });
 
-puppeteer.launch.resolves(mockBrowser);
+playwright.launch.resolves(mockBrowser);
 mockBrowser.newPage.resolves(mockPage);


### PR DESCRIPTION
## Overview

This PR replaces Puppeteer with Playwright as the headless browser. This opens up the possibility to support multiple browsers.

## Approach

In this PR I have attempted only to replace Puppeteer with Playwright as simply as possible. I have not looked into refactoring or optimization.

## Notes

+ Unlike Puppeteer, Playwright makes use of [browser contexts](https://playwright.dev/#version=v1.6.2&path=docs%2Fcore-concepts.md&q=browser-contexts) to save memory. This is an avenue that might be worth investigating, although it might involve a reasonably large refactor.

+ I have only used Playwright's Chromium browser, however it should be reasonably trivial to pass an option to select Chromium, Firefox or WebKit. I think it's reasonable to only run tests against the Chromium browser given that the API should be identical for all three browsers. I'd be happy to look into this in a new branch if you do decide to introduce Playwright.

+ Playwright will wait 30000ms for elements to be attached to the DOM before timing out, which is the same as Pa11y's default timeout, this means that Pa11y will timeout before Playwright will exit when a DOM element cannot be found. I have set the default timeout to 5000ms, which seemed like a reasonable setting, but this could be set as an option.

+ I am getting the following warning when running certain tests:
  ```
  Transformation error for /Users/mickyginger/development/frontendmentor/pa11y/lib/pa11y.js ; return original code
  Expected opts.sync to be a function.
  ```
  which I have not been able to resolve, I believe it has something to do with using ES6 import notation in node, but I cannot see where I have introduced that anywhere in the project.

+ My build seems to be failing on node v12.19.1 on Travis, however I am not able to replicate this locally, so I have not been able to investigate.