### PR TITLE
Removing references and code that refer to Section508

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Usage: pa11y [options] <url>
 
     -V, --version                  output the version number
     -n, --environment              output details about the environment Pa11y will run in
-    -s, --standard <name>          the accessibility standard to use: Section508, WCAG2A, WCAG2AA (default), WCAG2AAA – only used by htmlcs runner
+    -s, --standard <name>          the accessibility standard to use: WCAG2A, WCAG2AA (default), WCAG2AAA – only used by htmlcs runner
     -r, --reporter <reporter>      the reporter to use: cli (default), csv, json
     -e, --runner <runner>          the test runners to use: htmlcs (default), axe
     -l, --level <level>            the level of issue to fail on (exit with code 2): error, warning, notice
@@ -130,12 +130,6 @@ Run a test with CSV reporting and save to a file:
 
 ```
 pa11y --reporter csv http://example.com > report.csv
-```
-
-Run Pa11y with the Section508 ruleset:
-
-```
-pa11y --standard Section508 http://example.com
 ```
 
 Run Pa11y using [aXe] as a [test runner](#runners):
@@ -612,7 +606,7 @@ Defaults to:
 
 ### `rules` (array)
 
-An array of WCAG 2.0 guidelines that you'd like to include to the current standard. Note: These won't be applied to `Section508` standard. You can find the codes for each guideline in the [HTML Code Sniffer WCAG2AAA ruleset][htmlcs-wcag2aaa-ruleset]. **Note:** only used by htmlcs runner.
+An array of WCAG 2.0 guidelines that you'd like to include to the current standard. You can find the codes for each guideline in the [HTML Code Sniffer WCAG2AAA ruleset][htmlcs-wcag2aaa-ruleset]. **Note:** only used by htmlcs runner.
 
 ```js
 pa11y('http://example.com/', {
@@ -636,11 +630,11 @@ Defaults to `null`, meaning the screen will not be captured. Note the directory 
 
 ### `standard` (string)
 
-The accessibility standard to use when testing pages. This should be one of `Section508`, `WCAG2A`, `WCAG2AA`, or `WCAG2AAA`. **Note:** only used by htmlcs runner.
+The accessibility standard to use when testing pages. This should be one of `WCAG2A`, `WCAG2AA`, or `WCAG2AAA`. **Note:** only used by htmlcs runner.
 
 ```js
 pa11y('http://example.com/', {
-    standard: 'Section508'
+    standard: 'WCAG2A'
 });
 ```
 

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -30,7 +30,7 @@ function configureProgram() {
 		)
 		.option(
 			'-s, --standard <name>',
-			'the accessibility standard to use: Section508, WCAG2A, WCAG2AA (default), ' +
+			'the accessibility standard to use: WCAG2A, WCAG2AA (default), ' +
 			'WCAG2AAA – only used by htmlcs runner'
 		)
 		.option(

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -535,7 +535,6 @@ pa11y.defaults = {
  * @public
  */
 pa11y.allowedStandards = [
-	'Section508',
 	'WCAG2A',
 	'WCAG2AA',
 	'WCAG2AAA'

--- a/test/integration/cli/standard.test.js
+++ b/test/integration/cli/standard.test.js
@@ -55,30 +55,7 @@ describe('CLI standard', () => {
 
 	});
 
-	describe('when the `--standard` flag is set to "Section508"', () => {
-
-		before(async () => {
-			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
-				arguments: [
-					'--include-notices',
-					'--include-warnings',
-					'--standard', 'Section508',
-					'--reporter', 'json'
-				]
-			});
-		});
-
-		it('outputs the expected issues', () => {
-			assert.isArray(pa11yResponse.json);
-			assert.lengthEquals(pa11yResponse.json, 7);
-			pa11yResponse.json.forEach(issue => {
-				assert.match(issue.code, /^Section508\./);
-			});
-		});
-
-	});
-
-	describe('when the `standard` config is set to "WCAG2AAA" but the `--standard` flag is set to "Section508"', () => {
+	describe('when the `standard` config is set to "WCAG2AAA" but the `--standard` flag is set to "WCAG2AA"', () => {
 
 		before(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
@@ -86,7 +63,7 @@ describe('CLI standard', () => {
 					'--config', './mock/config/standard.json',
 					'--include-notices',
 					'--include-warnings',
-					'--standard', 'Section508',
+					'--standard', 'WCAG2AA',
 					'--reporter', 'json'
 				]
 			});
@@ -94,9 +71,9 @@ describe('CLI standard', () => {
 
 		it('outputs the expected issues', () => {
 			assert.isArray(pa11yResponse.json);
-			assert.lengthEquals(pa11yResponse.json, 7);
+			assert.lengthEquals(pa11yResponse.json, 28);
 			pa11yResponse.json.forEach(issue => {
-				assert.match(issue.code, /^Section508\./);
+				assert.match(issue.code, /^WCAG2AA\./);
 			});
 		});
 

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -353,7 +353,7 @@ describe('lib/pa11y', () => {
 
 			it('rejects with a descriptive error', () => {
 				assert.instanceOf(rejectedError, Error);
-				assert.strictEqual(rejectedError.message, 'Standard must be one of Section508, WCAG2A, WCAG2AA, WCAG2AAA');
+				assert.strictEqual(rejectedError.message, 'Standard must be one of WCAG2A, WCAG2AA, WCAG2AAA');
 			});
 
 		});

--- a/test/unit/mock/window.mock.js
+++ b/test/unit/mock/window.mock.js
@@ -19,13 +19,6 @@ module.exports = {
 		getMessages: sinon.stub().returns([]),
 		process: sinon.stub().yieldsAsync()
 	},
-	HTMLCS_Section508: {
-		sniffs: [
-			{
-				include: []
-			}
-		]
-	},
 	'HTMLCS_mock-standard': {
 		sniffs: [
 			{


### PR DESCRIPTION
Removing reference and code that refer to Section508 as it's no longer used per: https://github.com/pa11y/pa11y/issues/528

