### PR TITLE
Extract option functions to a new separate module

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const extend = require('node.extend');
+const path = require('path');
+
+module.exports.parseArguments = parseArguments;
+module.exports.verifyOptions = verifyOptions;
+
+/**
+ * Parse arguments from the command-line to properly identify the url, options, and callback
+ * @param {String} url - The URL to run tests against.
+ * @param {Object} [options={}] - Options to change the way tests run.
+ * @param {Object} [defaults] - Pa11y's defaults.
+ * @param {Function} [callback] - An optional callback to use instead of promises.
+ * @returns {Array} the new values of url, options, and callback
+ */
+function parseArguments(url, options, defaults, callback) {
+	if (!callback && typeof options === 'function') {
+		callback = options;
+		options = {};
+	}
+	if (typeof url !== 'string') {
+		options = url;
+		url = options.url;
+	}
+
+	url = sanitizeUrl(url, defaults);
+	options = defaultOptions(options, defaults);
+
+	return [url,
+		options,
+		callback];
+}
+
+/**
+ * Verify that passed in options are valid.
+ * @param {Object} options - The options to verify.
+ * @param {Object} allowedStandards - A list of standards allowed to be used.
+ * @returns {Undefined} Returns nothing.
+ * @throws {Error} Throws if options are not valid.
+ */
+function verifyOptions(options, allowedStandards) {
+	if (!allowedStandards.includes(options.standard)) {
+		throw new Error(`Standard must be one of ${allowedStandards.join(', ')}`);
+	}
+	if (options.page && !options.browser) {
+		throw new Error('The page option must only be set alongside the browser option');
+	}
+	if (options.ignoreUrl && !options.page) {
+		throw new Error('The ignoreUrl option must only be set alongside the page option');
+	}
+}
+
+/**
+ * Default the passed in options using Pa11y's defaults.
+ * @private
+ * @param {Object} [options] - The options to apply defaults to.
+ * @param {Object} [defaults] - Pa11y's defaults.
+ * @returns {Object} Returns the defaulted options.
+ */
+function defaultOptions(options, defaults) {
+
+	options = extend({}, defaults, options);
+
+	// Prevents problems if .ignore goes missing in the future because a change in defaults
+	if (options.ignore) {
+		options.ignore = options.ignore.map(ignored => ignored.toLowerCase());
+
+		// We now ignore warnings and notices by default since pa11y 5
+		if (!options.includeNotices) {
+			options.ignore.push('notice');
+		}
+		if (!options.includeWarnings) {
+			options.ignore.push('warning');
+		}
+	}
+
+	return options;
+}
+
+/**
+ * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period,
+ * it will be resolved as a path against the current working directory. If the URL does
+ * begin with a scheme, it will be prepended with "http://".
+ * @private
+ * @param {String} url - The URL to sanitize.
+ * @returns {String} Returns the sanitized URL.
+ */
+function sanitizeUrl(url) {
+	if (/^\//i.test(url)) {
+		return `file://${url}`;
+	}
+	if (/^\./i.test(url)) {
+		return `file://${path.resolve(process.cwd(), url)}`;
+	}
+	if (!/^(https?|file):\/\//i.test(url)) {
+		return `http://${url}`;
+	}
+	return url;
+}

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const runAction = require('./action');
-const extend = require('node.extend');
+const option = require('./option');
 const fs = require('fs');
-const path = require('path');
 const {promisify} = require('util');
 const pkg = require('../package.json');
 const promiseTimeout = require('p-timeout');
@@ -28,11 +27,11 @@ async function pa11y(url, options = {}, callback) {
 	const state = {};
 	let pa11yError;
 	let pa11yResults;
-	[url, options, callback] = parseArguments(url, options, callback);
+	[url, options, callback] = option.parseArguments(url, options, pa11y.defaults, callback);
 
 	try {
 		// Verify that the given options are valid
-		verifyOptions(options);
+		option.verifyOptions(options, pa11y.allowedStandards);
 
 		// Call the actual Pa11y test runner with
 		// a timeout if it takes too long
@@ -53,49 +52,6 @@ async function pa11y(url, options = {}, callback) {
 	}
 	// Run callback if present, and resolve with pa11yResults
 	return callback ? callback(pa11yError, pa11yResults) : pa11yResults;
-}
-
-/**
- * Parse arguments from the command-line to properly identify the url, options, and callback
- * @private
- * @param {String} url - The URL to run tests against.
- * @param {Object} [options={}] - Options to change the way tests run.
- * @param {Function} [callback] - An optional callback to use instead of promises.
- * @returns {Array} the new values of url, options, and callback
- */
-function parseArguments(url, options, callback) {
-	if (!callback && typeof options === 'function') {
-		callback = options;
-		options = {};
-	}
-	if (typeof url !== 'string') {
-		options = url;
-		url = options.url;
-	}
-	url = sanitizeUrl(url);
-	options = defaultOptions(options);
-
-	return [url,
-		options,
-		callback];
-}
-
-/**
- * Default the passed in options using Pa11y's defaults.
- * @private
- * @param {Object} [options] - The options to apply defaults to.
- * @returns {Object} Returns the defaulted options.
- */
-function defaultOptions(options) {
-	options = extend({}, pa11y.defaults, options);
-	options.ignore = options.ignore.map(ignored => ignored.toLowerCase());
-	if (!options.includeNotices) {
-		options.ignore.push('notice');
-	}
-	if (!options.includeWarnings) {
-		options.ignore.push('warning');
-	}
-	return options;
 }
 
 /**
@@ -390,46 +346,6 @@ async function saveScreenCapture(options, state) {
 			options.log.error(`Error capturing screen: ${error.message}`);
 		}
 	}
-}
-
-/**
- * Verify that passed in options are valid.
- * @private
- * @param {Object} options - The options to verify.
- * @returns {Undefined} Returns nothing.
- * @throws {Error} Throws if options are not valid.
- */
-function verifyOptions(options) {
-	if (!pa11y.allowedStandards.includes(options.standard)) {
-		throw new Error(`Standard must be one of ${pa11y.allowedStandards.join(', ')}`);
-	}
-	if (options.page && !options.browser) {
-		throw new Error('The page option must only be set alongside the browser option');
-	}
-	if (options.ignoreUrl && !options.page) {
-		throw new Error('The ignoreUrl option must only be set alongside the page option');
-	}
-}
-
-/**
- * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period,
- * it will be resolved as a path against the current working directory. If the URL does
- * begin with a scheme, it will be prepended with "http://".
- * @private
- * @param {String} url - The URL to sanitize.
- * @returns {String} Returns the sanitized URL.
- */
-function sanitizeUrl(url) {
-	if (/^\//i.test(url)) {
-		return `file://${url}`;
-	}
-	if (/^\./i.test(url)) {
-		return `file://${path.resolve(process.cwd(), url)}`;
-	}
-	if (!/^(https?|file):\/\//i.test(url)) {
-		return `http://${url}`;
-	}
-	return url;
 }
 
 /**

--- a/test/unit/lib/option.test.js
+++ b/test/unit/lib/option.test.js
@@ -1,0 +1,285 @@
+'use strict';
+
+const assert = require('proclaim');
+const path = require('path');
+
+describe('lib/option', () => {
+	const noop = () => { /* No-op */ };
+
+	let defaults;
+	let option;
+
+	beforeEach(() => {
+		defaults = {
+			actions: [],
+			browser: null,
+			chromeLaunchConfig: {
+				ignoreHTTPSErrors: true
+			},
+			headers: {},
+			hideElements: null,
+			ignore: [],
+			ignoreUrl: false,
+			includeNotices: false,
+			includeWarnings: false,
+			log: {
+				debug: noop,
+				error: noop,
+				info: noop
+			},
+			method: 'GET',
+			postData: null,
+			rootElement: null,
+			rules: [],
+			runners: [
+				'htmlcs'
+			],
+			screenCapture: null,
+			standard: 'WCAG2AA',
+			timeout: 30000,
+			userAgent: `pa11y/1.2.3`,
+			viewport: {
+				width: 1280,
+				height: 1024
+			},
+			wait: 0
+		};
+
+		option = require('../../../lib/option');
+	});
+
+	it('is a function', () => {
+		assert.isFunction(option.parseArguments);
+	});
+
+	describe('parseArguments(url, options, defaults, callback)', () => {
+		// eslint-disable-next-line no-unused-vars
+		let url;
+		let options;
+		// eslint-disable-next-line no-unused-vars
+		let callback;
+
+		beforeEach(() => {
+			options = {
+				mockOptions: true,
+				timeout: 60000,
+				url: 'https://mock-url/',
+				log: {
+					debug: noop,
+					error: noop,
+					info: noop
+				},
+				runners: [
+					'axe',
+					'htmlcs'
+				]
+			};
+		});
+
+		it('defaults the options object with `pa11y.defaults`', () => {
+			const resultingOptions = {
+				actions: [],
+				browser: null,
+				chromeLaunchConfig: {
+					ignoreHTTPSErrors: true
+				},
+				headers: {},
+				hideElements: null,
+				ignore: [
+					'notice',
+					'warning'
+				],
+				ignoreUrl: false,
+				includeNotices: false,
+				includeWarnings: false,
+				log: {
+					debug: noop,
+					error: noop,
+					info: noop
+				},
+				method: 'GET',
+				mockOptions: true,
+				postData: null,
+				rootElement: null,
+				rules: [],
+				runners: [
+					'axe',
+					'htmlcs'
+				],
+				screenCapture: null,
+				standard: 'WCAG2AA',
+				timeout: 60000,
+				url: 'https://mock-url/',
+				userAgent: `pa11y/1.2.3`,
+				viewport: {
+					width: 1280,
+					height: 1024
+				},
+				wait: 0
+			};
+
+			[url, options, callback] = option.parseArguments('', options, defaults);
+			assert.deepEqual(resultingOptions, options);
+		});
+
+		it('returns the defaults when options are empty', () => {
+			const defaultsWithEmptyOptions = {
+				actions: [],
+				browser: null,
+				chromeLaunchConfig: {
+					ignoreHTTPSErrors: true
+				},
+				headers: {},
+				hideElements: null,
+				ignore: [
+					'notice',
+					'warning'
+				],
+				ignoreUrl: false,
+				includeNotices: false,
+				includeWarnings: false,
+				log: {
+					debug: noop,
+					error: noop,
+					info: noop
+				},
+				method: 'GET',
+				postData: null,
+				rootElement: null,
+				rules: [],
+				runners: [
+					'htmlcs'
+				],
+				screenCapture: null,
+				standard: 'WCAG2AA',
+				timeout: 30000,
+				userAgent: `pa11y/1.2.3`,
+				viewport: {
+					width: 1280,
+					height: 1024
+				},
+				wait: 0
+			};
+
+			[url, options, callback] = option.parseArguments('', {}, defaults);
+			assert.deepEqual(defaultsWithEmptyOptions, options);
+		});
+
+		describe('when defaults and options are both empty', () => {
+			beforeEach(() => {
+				[url, options, callback] = option.parseArguments('', {}, {});
+			});
+
+			it('returns an empty object', () => {
+				assert.deepEqual(options, {});
+			});
+		});
+
+		describe('when `url` does not have a scheme', () => {
+			beforeEach(() => {
+				[url, options, callback] = option.parseArguments('mock-url', {}, {});
+			});
+
+			it('navigates to `url` with an `http` scheme added', () => {
+				assert.equal(url, 'http://mock-url');
+			});
+		});
+
+		describe('when `url` does not have a scheme and starts with a slash', () => {
+			beforeEach(() => {
+				[url, options, callback] = option.parseArguments('/mock-path', {}, {});
+			});
+
+			it('navigates to `url` with a `file` scheme added', () => {
+				assert.equal(url, 'file:///mock-path');
+			});
+		});
+
+		describe('when `url` does not have a scheme and starts with a period', () => {
+			beforeEach(() => {
+				[url, options, callback] = option.parseArguments('./mock-path', {}, {});
+			});
+
+			it('navigates to `url` with an `file` scheme added and a resolved path', () => {
+				const resolvedPath = path.resolve(process.cwd(), './mock-path');
+				assert.equal(url, `file://${resolvedPath}`);
+			});
+
+		});
+
+	});
+
+	it('is a function', () => {
+		assert.isFunction(option.verifyOptions);
+	});
+
+	describe('verifyOptions(options, allowedStandards)', () => {
+		const allowedStandards = [
+			'Section508',
+			'WCAG2A',
+			'WCAG2AA',
+			'WCAG2AAA'
+		];
+
+		describe('when `options.standard` is invalid', () => {
+			const options = {};
+			let rejectedError;
+
+			beforeEach(() => {
+				options.standard = 'not-a-standard';
+				try {
+					option.verifyOptions(options, allowedStandards);
+				} catch (error) {
+					rejectedError = error;
+				}
+			});
+
+			it('rejects with a descriptive error', () => {
+				assert.instanceOf(rejectedError, Error);
+				assert.strictEqual(rejectedError.message, 'Standard must be one of Section508, WCAG2A, WCAG2AA, WCAG2AAA');
+			});
+		});
+
+		describe('when puppeteer\'s `options.page` is present but `options.browser` is missing', () => {
+			const options = {
+				page: {},
+				standard: 'WCAG2AA'
+			};
+			let rejectedError;
+
+			beforeEach(() => {
+				try {
+					option.verifyOptions(options, allowedStandards);
+				} catch (error) {
+					rejectedError = error;
+				}
+			});
+
+			it('rejects with a descriptive error', () => {
+				assert.instanceOf(rejectedError, Error);
+				assert.strictEqual(rejectedError.message, 'The page option must only be set alongside the browser option');
+			});
+		});
+
+		describe('when `ignoreUrl` is present but `options.page` is missing', () => {
+			const options = {
+				ignoreUrl: true,
+				standard: 'WCAG2AA'
+			};
+			let rejectedError;
+
+			beforeEach(() => {
+				try {
+					option.verifyOptions(options, allowedStandards);
+				} catch (error) {
+					rejectedError = error;
+				}
+			});
+
+			it('rejects with a descriptive error', () => {
+				assert.instanceOf(rejectedError, Error);
+				assert.strictEqual(rejectedError.message, 'The ignoreUrl option must only be set alongside the page option');
+			});
+		});
+	});
+});


### PR DESCRIPTION
Extracts the functions in `lib/pa11y` related to argument parsing and option processing (`parseArguments`, `verifyOptions`, `defaultOptions` and `sanitizeUrl`) to a separate module.

Only `parseArguments` and `verifyOptions` function is used somewhere else, so the module has a clean, simple interface.

No changes to the existing tests were necessary in order for them to pass, but I've extracted the parts of the tests related to these options to their own file.
