### PR TITLE
Merge reporter cli

### DIFF
--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -197,6 +197,7 @@ function loadReporter(name) {
 
 	try {
 		reporterMethods = requireFirst([
+			`../lib/reporters/${name}`,
 			`pa11y-reporter-${name}`,
 			path.join(process.cwd(), name)
 		], null);

--- a/lib/reporters/cli.js
+++ b/lib/reporters/cli.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const {cyan, green, grey, red, underline, yellow} = require('kleur');
+
+const report = module.exports = {};
+
+// Pa11y version support
+report.supports = '^6.0.0 || ^6.0.0-alpha || ^6.0.0-beta';
+
+// Helper strings for use in reporter methods
+const start = cyan(' >');
+const typeStarts = {
+	error: red(' • Error:'),
+	notice: cyan(' • Notice:'),
+	unknown: grey(' •'),
+	warning: yellow(' • Warning:')
+};
+
+// Output the welcome message once Pa11y begins testing
+report.begin = () => {
+	return cleanWhitespace(`
+
+		${cyan(underline('Welcome to Pa11y'))}
+
+	`);
+};
+
+// Output formatted results
+report.results = results => {
+	if (results.issues.length) {
+		return cleanWhitespace(`
+
+			${underline(`Results for URL: ${results.pageUrl}`)}
+			${results.issues.map(report.issue).join('\n')}
+
+			${report.totals(results)}
+
+		`);
+	}
+	return cleanWhitespace(`
+
+		${green('No issues found!')}
+
+	`);
+};
+
+// Internal method used to report an individual result
+report.issue = issue => {
+	const code = issue.code;
+	const selector = issue.selector.replace(/\s+/g, ' ');
+	const context = (issue.context ? issue.context.replace(/\s+/g, ' ') : '[no context]');
+	return cleanWhitespace(`
+
+		${typeStarts[issue.type]} ${issue.message}
+		   ${grey(`├── ${code}`)}
+		   ${grey(`├── ${selector}`)}
+		   ${grey(`└── ${context}`)}
+	`);
+};
+
+// Internal method used to report issue totals
+report.totals = results => {
+	const totals = {
+		errors: results.issues.filter(issue => issue.type === 'error').length,
+		warnings: results.issues.filter(issue => issue.type === 'warning').length,
+		notices: results.issues.filter(issue => issue.type === 'notice').length
+	};
+	const output = [];
+	if (totals.errors > 0) {
+		output.push(red(`${totals.errors} Errors`));
+	}
+	if (totals.warnings > 0) {
+		output.push(yellow(`${totals.warnings} Warnings`));
+	}
+	if (totals.notices > 0) {
+		output.push(cyan(`${totals.notices} Notices`));
+	}
+	return output.join('\n');
+};
+
+// Output error messages
+report.error = message => {
+	if (!/^error:/i.test(message)) {
+		message = `Error: ${message}`;
+	}
+	return cleanWhitespace(`
+
+		${red(message)}
+
+	`);
+};
+
+// Output debug messages
+report.debug = message => {
+	message = `Debug: ${message}`;
+	return cleanWhitespace(`
+		${start} ${grey(message)}
+	`);
+};
+
+// Output information messages
+report.info = message => {
+	return cleanWhitespace(`
+		${start} ${message}
+	`);
+};
+
+// Clean whitespace from output. This function is used to keep
+// the reporter code a little cleaner
+function cleanWhitespace(string) {
+	return string.replace(/\t+|^\t*\n|\n\t*$/g, '');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,9 +1699,9 @@
       "dev": true
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
     "levn": {
       "version": "0.3.0",
@@ -2287,14 +2287,6 @@
       "resolved": "https://registry.npmjs.org/pa11y-lint-config/-/pa11y-lint-config-1.2.1.tgz",
       "integrity": "sha512-pt9rc9lTgce/rgdbPcpzMAvbfAwydmLWqRk8fOpacXynIdE9YMyXrxU3hDxRWJ/rdXKnMheUpJPTAbizEaSJAg==",
       "dev": true
-    },
-    "pa11y-reporter-cli": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-2.0.0.tgz",
-      "integrity": "sha512-lqxBgQyJZMvQ0V0SbxZttO8U2Jx0AU65kZtF+oj5wamdzWH1O93pGZN9obyhCj7C3tD6Ihz6c7Kflo5M8ieIug==",
-      "requires": {
-        "kleur": "^3.0.3"
-      }
     },
     "pa11y-reporter-csv": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "dependencies": {
     "commander": "^3.0.2",
     "envinfo": "^7.5.0",
+    "kleur": "^4.1.4",
     "node.extend": "^2.0.2",
     "p-timeout": "^2.0.1",
-    "pa11y-reporter-cli": "^2.0.0",
     "pa11y-reporter-csv": "^2.0.0",
     "pa11y-reporter-json": "^2.0.0",
     "pa11y-runner-axe": "^2.0.0",

--- a/test/unit/lib/reporters/cli.js
+++ b/test/unit/lib/reporters/cli.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const mockery = require('mockery');
+const assert = require('proclaim');
+
+describe('lib/reporters/cli', () => {
+	let kleur;
+	let cliReporter;
+
+	beforeEach(() => {
+		kleur = require('../../mock/kleur');
+		mockery.registerMock('kleur', kleur);
+		cliReporter = require('../../../lib/reporters/cli');
+	});
+
+	it('is an object', () => {
+		assert.isObject(cliReporter);
+	});
+
+	it('has a `supports` property', () => {
+		assert.isString(cliReporter.supports);
+	});
+
+	it('has a `begin` method', () => {
+		assert.isFunction(cliReporter.begin);
+	});
+
+	describe('.begin()', () => {
+
+		it('returns a welcome message decorated for CLI output', () => {
+			assert.strictEqual(cliReporter.begin(), '\nWelcome to Pa11y\n');
+		});
+
+	});
+
+	it('has a `results` method', () => {
+		assert.isFunction(cliReporter.results);
+	});
+
+	describe('.results(pa11yResults)', () => {
+		let mockPa11yResults;
+
+		beforeEach(() => {
+			mockPa11yResults = {
+				documentTitle: 'mock title',
+				pageUrl: 'http://mock-url/',
+				issues: [
+					{
+						type: 'error',
+						code: 'mock-code-1',
+						message: 'mock-message-1',
+						context: 'mock-context-1',
+						selector: 'mock-selector-1'
+					},
+					{
+						type: 'warning',
+						code: 'mock-code-2',
+						message: 'mock-message-2',
+						context: 'mock-context-2',
+						selector: 'mock-selector-2'
+					},
+					{
+						type: 'notice',
+						code: 'mock-code-3',
+						message: 'mock-message-3',
+						context: null,
+						selector: 'mock-selector-3'
+					}
+				]
+			};
+		});
+
+		it('returns the issues decorated for CLI output', () => {
+			assert.strictEqual(cliReporter.results(mockPa11yResults), `
+				Results for URL: http://mock-url/
+
+				 • Error: mock-message-1
+				   ├── mock-code-1
+				   ├── mock-selector-1
+				   └── mock-context-1
+
+				 • Warning: mock-message-2
+				   ├── mock-code-2
+				   ├── mock-selector-2
+				   └── mock-context-2
+
+				 • Notice: mock-message-3
+				   ├── mock-code-3
+				   ├── mock-selector-3
+				   └── [no context]
+
+				1 Errors
+				1 Warnings
+				1 Notices
+			`.replace(/\t+/g, ''));
+		});
+
+		describe('when `pa11yResults` has no errors', () => {
+
+			beforeEach(() => {
+				mockPa11yResults.issues = mockPa11yResults.issues.filter(issue => {
+					return issue.type !== 'error';
+				});
+			});
+
+			it('Does not include the error summary in the output', () => {
+				assert.notMatch(cliReporter.results(mockPa11yResults), /1 errors/i);
+			});
+
+		});
+
+		describe('when `pa11yResults` has no warnings', () => {
+
+			beforeEach(() => {
+				mockPa11yResults.issues = mockPa11yResults.issues.filter(issue => {
+					return issue.type !== 'warning';
+				});
+			});
+
+			it('Does not include the warning summary in the output', () => {
+				assert.notMatch(cliReporter.results(mockPa11yResults), /1 warnings/i);
+			});
+
+		});
+
+		describe('when `pa11yResults` has no notices', () => {
+
+			beforeEach(() => {
+				mockPa11yResults.issues = mockPa11yResults.issues.filter(issue => {
+					return issue.type !== 'notice';
+				});
+			});
+
+			it('Does not include the notice summary in the output', () => {
+				assert.notMatch(cliReporter.results(mockPa11yResults), /1 notices/i);
+			});
+
+		});
+
+		describe('when `pa11yResults` has no issues', () => {
+
+			beforeEach(() => {
+				mockPa11yResults.issues = [];
+			});
+
+			it('returns a success message', () => {
+				assert.strictEqual(cliReporter.results(mockPa11yResults), `
+					No issues found!
+				`.replace(/\t+/g, ''));
+			});
+
+		});
+
+	});
+
+	it('has an `error` method', () => {
+		assert.isFunction(cliReporter.error);
+	});
+
+	describe('.error(message)', () => {
+
+		it('returns the message decorated for CLI output', () => {
+			assert.strictEqual(cliReporter.error('mock message'), '\nError: mock message\n');
+		});
+
+		describe('when `message` already starts with the text "Error:"', () => {
+
+			it('returns the message decorated for CLI output, not adding "Error:"', () => {
+				assert.strictEqual(cliReporter.error('Error: mock'), '\nError: mock\n');
+			});
+
+		});
+
+	});
+
+	it('has an `info` method', () => {
+		assert.isFunction(cliReporter.info);
+	});
+
+	describe('.info(message)', () => {
+
+		it('returns the message decorated for CLI output', () => {
+			assert.strictEqual(cliReporter.info('mock message'), ' > mock message');
+		});
+
+	});
+
+	it('has a `debug` method', () => {
+		assert.isFunction(cliReporter.debug);
+	});
+
+	describe('.debug(message)', () => {
+
+		it('returns the message decorated for CLI output', () => {
+			assert.strictEqual(cliReporter.debug('mock message'), ' > Debug: mock message');
+		});
+
+	});
+
+});

--- a/test/unit/mock/kleur.js
+++ b/test/unit/mock/kleur.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const kleur = {
+	cyan: sinon.stub().returnsArg(0),
+	green: sinon.stub().returnsArg(0),
+	grey: sinon.stub().returnsArg(0),
+	red: sinon.stub().returnsArg(0),
+	underline: sinon.stub().returnsArg(0),
+	yellow: sinon.stub().returnsArg(0)
+};
+
+// Allow for chaining
+for (const key1 of Object.keys(kleur)) {
+	for (const key2 of Object.keys(kleur)) {
+		kleur[key1][key2] = kleur[key2];
+	}
+}
+
+module.exports = kleur;


### PR DESCRIPTION
Merges the pa11y-reporter-cli repo into pa11y, preserving the git history of the reporter.

The only change required to pa11y to support this is to first check ../lib/reporters/${name} for the reporter. The reporter itself has intentionally not been changed at all, however once all reporters are merged we can drop the version bits and bobs and speed up how we load the internal reporters (i.e. keep a map of internal reporters which we can require directly without a try/catch).