### PR TITLE
Update README for v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-
-Pa11y
-=====
+# Pa11y
 
 Pa11y is your automated accessibility testing pal. It runs accessibility tests on your pages via the command line or Node.js, so you can automate your testing process.
 
@@ -12,7 +10,7 @@ Pa11y is your automated accessibility testing pal. It runs accessibility tests o
 On the command line:
 
 ```sh
-pa11y http://example.com/
+pa11y https://example.com/
 ```
 
 In JavaScript:
@@ -20,73 +18,111 @@ In JavaScript:
 ```js
 const pa11y = require('pa11y');
 
-pa11y('http://example.com/').then((results) => {
+pa11y('https://example.com/').then((results) => {
     // Do something with the results
 });
 ```
 
 If you need a GUI, you can try [Koa11y](https://open-indy.github.io/Koa11y/). It's a desktop application for Windows, OSX and Linux that uses Pa11y to run accessibility tests.
 
-Table Of Contents
------------------
+## Table of contents
 
-- [Requirements](#requirements)
-- [Command-Line Interface](#command-line-interface)
-- [JavaScript Interface](#javascript-interface)
-- [Configuration](#configuration)
-- [Actions](#actions)
-- [Runners](#runners)
-- [Examples](#examples)
-- [Common Questions and Troubleshooting](#common-questions-and-troubleshooting)
-- [Tutorials and articles](#tutorials-and-articles)
-- [Contributing](#contributing)
-- [Support and Migration](#support-and-migration)
-- [License](#license)
+* [Table of contents](#table-of-contents)
+* [Requirements](#requirements)
+  * [Linux and macOS](#linux-and-macos)
+  * [Windows](#windows)
+* [Command-Line Interface](#command-line-interface)
+  * [Running Tests](#running-tests)
+  * [Exit Codes](#exit-codes)
+  * [Command-Line Configuration](#command-line-configuration)
+  * [Ignoring](#ignoring)
+  * [Reporters](#reporters)
+* [JavaScript Interface](#javascript-interface)
+  * [Transforming the Results](#transforming-the-results)
+  * [Async/Await](#asyncawait)
+  * [Callback interface](#callback-interface)
+  * [Validating actions](#validating-actions)
+* [Configuration](#configuration)
+  * [`actions` (array)](#actions-array)
+  * [`browser` (Browser) and `page` (Page)](#browser-browser-and-page-page)
+  * [`chromeLaunchConfig` (object)](#chromelaunchconfig-object)
+  * [`headers` (object)](#headers-object)
+  * [`hideElements` (string)](#hideelements-string)
+  * [`ignore` (array)](#ignore-array)
+  * [`ignoreUrl` (boolean)](#ignoreurl-boolean)
+  * [`includeNotices` (boolean)](#includenotices-boolean)
+  * [`includeWarnings` (boolean)](#includewarnings-boolean)
+  * [`level` (string)](#level-string)
+  * [`log` (object)](#log-object)
+  * [`method` (string)](#method-string)
+  * [`postData` (string)](#postdata-string)
+  * [`reporter` (string)](#reporter-string)
+  * [`rootElement` (element)](#rootelement-element)
+  * [`runners` (array)](#runners-array)
+  * [`rules` (array)](#rules-array)
+  * [`screenCapture` (string)](#screencapture-string)
+  * [`standard` (string)](#standard-string)
+  * [`threshold` (number)](#threshold-number)
+  * [`timeout` (number)](#timeout-number)
+  * [`userAgent` (string)](#useragent-string)
+  * [`viewport` (object)](#viewport-object)
+  * [`wait` (number)](#wait-number)
+* [Actions](#actions)
+  * [Click Element](#click-element)
+  * [Set Field Value](#set-field-value)
+  * [Check/Uncheck Field](#checkuncheck-field)
+  * [Screen Capture](#screen-capture)
+  * [Wait For Fragment/Path/URL](#wait-for-fragmentpathurl)
+  * [Wait For Element State](#wait-for-element-state)
+  * [Wait For Element Event](#wait-for-element-event)
+  * [Navigate To URL](#navigate-to-url)
+* [Runners](#runners)
+* [Examples](#examples)
+  * [Basic Example](#basic-example)
+  * [Multiple Example](#multiple-example)
+  * [Actions Example](#actions-example)
+  * [Puppeteer Example](#puppeteer-example)
+* [Common Questions and Troubleshooting](#common-questions-and-troubleshooting)
+* [Tutorials and articles](#tutorials-and-articles)
+* [Contributing](#contributing)
+* [Support and Migration](#support-and-migration)
+* [License](#license)
 
+## Requirements
 
-Requirements
-------------
+Pa11y requires [Node.js][node] 12+ to run. If you need support for older versions of Node.js, then please use [Pa11y 5.x][5.x].
 
-Pa11y requires [Node.js][node] 8+ to run. If you need support for older versions of Node.js, then please use [Pa11y 4.x][4.x].
-
-### OS X
+### Linux and macOS
 
 To install [Node.js][node] you can use [nvm][nvm]:
-```sh
-$ nvm install node
-```
-
-Alternatively on a Mac, you can install the required dependency with [Homebrew][brew]:
 
 ```sh
-$ brew install node
+nvm install node
 ```
 
-You can also download pre-built packages from the [Node.js][node] website.
+You can also install Node.js using a package manager like for example [Homebrew][brew]:
 
-### Linux
+```sh
+brew install node
+```
 
-Depending on your flavour of Linux, you should be able to use a package manager to install the required dependency. Alternatively download pre-built packages from the [Node.js][node] website.
+Alternatively, you can also download pre-built packages from the [Node.js][node] website for your particular Operating System.
 
 ### Windows
 
 On Windows 10, download a pre-built package from the [Node.js][node] website. Pa11y will be usable via the bundled Node.js application as well as the Windows command prompt.
 
-Windows 7 and below users approach with caution – we've been able to get Pa11y running but only after installing Visual Studio and the Windows SDK (as well as Git, and Python). The [Windows installation instructions for node-gyp][windows-install] are a good place to start. If you have had a better experience than this then please do share!
-
-
-Command-Line Interface
-----------------------
+## Command-Line Interface
 
 Install Pa11y globally with [npm][npm]:
 
-```
+```sh
 npm install -g pa11y
 ```
 
 This installs the `pa11y` command-line tool:
 
-```
+```sh
 Usage: pa11y [options] <url>
 
   Options:
@@ -116,55 +152,55 @@ Usage: pa11y [options] <url>
 
 Run an accessibility test against a URL:
 
-```
-pa11y http://example.com
+```sh
+pa11y https://example.com
 ```
 
 Run an accessibility test against a file (absolute paths only, not relative):
 
-```
+```sh
 pa11y ./path/to/your/file.html
 ```
 
 Run a test with CSV reporting and save to a file:
 
-```
-pa11y --reporter csv http://example.com > report.csv
+```sh
+pa11y --reporter csv https://example.com > report.csv
 ```
 
 Run Pa11y using [aXe] as a [test runner](#runners):
 
-```
-pa11y --runner axe http://example.com
+```sh
+pa11y --runner axe https://example.com
 ```
 
 Run Pa11y using [aXe] _and_ [HTML CodeSniffer][htmlcs] as [test runners](#runners):
 
-```
-pa11y --runner axe --runner htmlcs http://example.com
+```sh
+pa11y --runner axe --runner htmlcs https://example.com
 ```
 
 ### Exit Codes
 
 The command-line tool uses the following exit codes:
 
-  - `0`: Pa11y ran successfully, and there are no errors
-  - `1`: Pa11y failed run due to a technical fault
-  - `2`: Pa11y ran successfully but there are errors in the page
+* `0`: Pa11y ran successfully, and there are no errors
+* `1`: Pa11y failed run due to a technical fault
+* `2`: Pa11y ran successfully but there are errors in the page
 
 By default, only accessibility issues with a type of `error` will exit with a code of `2`. This is configurable with the `--level` flag which can be set to one of the following:
 
-  - `error`: exit with a code of `2` on errors only, exit with a code of `0` on warnings and notices
-  - `warning`: exit with a code of `2` on errors and warnings, exit with a code of `0` on notices
-  - `notice`: exit with a code of `2` on errors, warnings, and notices
-  - `none`: always exit with a code of `0`
+* `error`: exit with a code of `2` on errors only, exit with a code of `0` on warnings and notices
+* `warning`: exit with a code of `2` on errors and warnings, exit with a code of `0` on notices
+* `notice`: exit with a code of `2` on errors, warnings, and notices
+* `none`: always exit with a code of `0`
 
 ### Command-Line Configuration
 
 The command-line tool can be configured with a JSON file as well as arguments. By default it will look for a `pa11y.json` file in the current directory, but you can change this with the `--config` flag:
 
-```
-pa11y --config ./path/to/config.json http://example.com
+```sh
+pa11y --config ./path/to/config.json https://example.com
 ```
 
 If any configuration is set both in a configuration file and also as a command-line option, the value set in the latter will take priority.
@@ -175,44 +211,42 @@ For more information on configuring Pa11y, see the [configuration documentation]
 
 The ignore flag can be used in several different ways. Separated by semi-colons:
 
-```
-pa11y --ignore "issue-code-1;issue-code-2" http://example.com
+```sh
+pa11y --ignore "issue-code-1;issue-code-2" https://example.com
 ```
 
 or by using the flag multiple times:
 
-```
-pa11y --ignore issue-code-1 --ignore issue-code-2 http://example.com
+```sh
+pa11y --ignore issue-code-1 --ignore issue-code-2 https://example.com
 ```
 
 Pa11y can also ignore notices, warnings, and errors up to a threshold number. This might be useful if you're using CI and don't want to break your build. The following example will return exit code 0 on a page with 9 errors, and return exit code 2 on a page with 10 or more errors.
 
-```
-pa11y --threshold 10 http://example.com
+```sh
+pa11y --threshold 10 https://example.com
 ```
 
 ### Reporters
 
 The command-line tool can report test results in a few different ways using the `--reporter` flag. The built-in reporters are:
 
-  - `cli`: output test results in a human-readable format
-  - `csv`: output test results as comma-separated values
-  - `json`: output test results as a JSON array
+* `cli`: output test results in a human-readable format
+* `csv`: output test results as comma-separated values
+* `json`: output test results as a JSON array
+* `tsv`: output test results as tab-separated values
 
-The Pa11y team maintain some additional reporters which can be installed separately via `npm`:
-
-  - [`html`](https://github.com/pa11y/pa11y-reporter-html): output test results in a self-contained HTML format (`npm install pa11y-reporter-html`)
-  - [`tsv`](https://github.com/pa11y/pa11y-reporter-tsv): output test results as tab-separated values (`npm install pa11y-reporter-tsv`)
+The Pa11y team maintain an additional [`html`](https://github.com/pa11y/pa11y-reporter-html) reporter that can be installed separately via `npm` and can be used as an example of how to build more complex reporters.
 
 You can also write and publish your own reporters. Pa11y looks for reporters in your `node_modules` folder (with a naming pattern), and the current working directory. The first reporter found will be loaded. So with this command:
 
 ```sh
-pa11y --reporter rainbows http://example.com
+pa11y --reporter rainbows https://example.com
 ```
 
 The following locations will be checked:
 
-```
+```sh
 <cwd>/node_modules/pa11y-reporter-rainbows
 <cwd>/rainbows
 ```
@@ -233,9 +267,7 @@ info(message); // Called when an information message is reported
 results(results); // Called with the results of a test run
 ```
 
-
-JavaScript Interface
---------------------
+## JavaScript Interface
 
 Install Pa11y with [npm][npm] or add to your `package.json`:
 
@@ -252,7 +284,7 @@ const pa11y = require('pa11y');
 Run Pa11y against a URL, the `pa11y` function returns a [Promise]:
 
 ```js
-pa11y('http://example.com/').then((results) => {
+pa11y('https://example.com/').then((results) => {
     // Do something with the results
 });
 ```
@@ -260,7 +292,7 @@ pa11y('http://example.com/').then((results) => {
 Pa11y can also be run with [some options](#configuration):
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     // Options go here
 }).then((results) => {
     // Do something with the results
@@ -276,7 +308,7 @@ Pa11y resolves with a `results` object, containing details about the page and ac
     issues: [
         {
             code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
-            context: '<a href="http://example.com/"><img src="example.jpg" alt=""/></a>',
+            context: '<a href="https://example.com/"><img src="example.jpg" alt=""/></a>',
             message: 'Img element is the only content of the link, but is missing alt text. The alt text should describe the purpose of the link.',
             selector: 'html > body > p:nth-child(1) > a',
             type: 'error',
@@ -305,7 +337,7 @@ Because Pa11y is promise based, you can use `async` functions and the `await` ke
 ```js
 async function runPa11y() {
     try {
-        const results = await pa11y('http://example.com/');
+        const results = await pa11y('https://example.com/');
         // Do something with the results
     } catch (error) {
         // Handle the error
@@ -315,17 +347,17 @@ async function runPa11y() {
 runPa11y();
 ```
 
-### Callback Interface
+### Callback interface
 
 If you would rather use callbacks than promises or `async`/`await`, then Pa11y supports this. This interface should be considered legacy, however, and may not appear in the next major version of Pa11y:
 
 ```js
-pa11y('http://example.com/', (error, results) => {
+pa11y('https://example.com/', (error, results) => {
     // Do something with the results or handle the error
 });
 ```
 
-### Validating Actions
+### Validating actions
 
 Pa11y exposes a function which allows you to validate [action](#actions) strings before attempting to use them.
 
@@ -336,22 +368,18 @@ pa11y.isValidAction('click element #submit');  // true
 pa11y.isValidAction('open the pod bay doors'); // false
 ```
 
-
-Configuration
--------------
+## Configuration
 
 Pa11y has lots of options you can use to change the way Headless Chrome runs, or the way your page is loaded. Options can be set either as a parameter on the `pa11y` function or in a [JSON configuration file](#command-line-configuration). Some are also available directly as [command-line options](#command-line-interface).
 
 Below is a reference of all the options that are available:
 
-### `actions` (array) **BETA**
+### `actions` (array)
 
 Actions to be run before Pa11y tests the page. There are quite a few different actions available in Pa11y, the [Actions documentation](#actions) outlines each of them.
 
-**Note:** actions are currently in a beta state and the API may change while we gather feedback.
-
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'set field #username to exampleUser',
         'set field #password to password1234',
@@ -381,7 +409,7 @@ const browser = await puppeteer.launch({
     ignoreHTTPSErrors: true
 });
 
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     browser: browser
 });
 
@@ -397,7 +425,7 @@ Defaults to `null`.
 Launch options for the Headless Chrome instance. [See the Puppeteer documentation for more information][puppeteer-launch].
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     chromeLaunchConfig: {
         executablePath: '/path/to/Chrome',
         ignoreHTTPSErrors: false
@@ -418,7 +446,7 @@ Defaults to:
 A key-value map of request headers to send when testing a web page.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     headers: {
         Cookie: 'foo=bar'
     }
@@ -432,7 +460,7 @@ Defaults to an empty object.
 A CSS selector to hide elements from testing, selectors can be comma separated. Elements matching this selector will be hidden from testing by styling them with `visibility: hidden`.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     hideElements: '.advert, #modal, div[aria-role=presentation]'
 });
 ```
@@ -442,7 +470,7 @@ pa11y('http://example.com/', {
 An array of result codes and types that you'd like to ignore. You can find the codes for each rule in the console output and the types are `error`, `warning`, and `notice`. Note: `warning` and `notice` messages are ignored by default.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     ignore: [
         'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2'
     ]
@@ -459,7 +487,7 @@ Whether to use the provided [Puppeteer Page instance][puppeteer-page] as is or u
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
 
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     ignoreUrl: true,
     page: page,
     browser: browser
@@ -473,7 +501,7 @@ Defaults to `false`.
 Whether to include results with a type of `notice` in the Pa11y report. Issues with a type of `notice` are not directly actionable and so they are excluded by default. You can include them by using this option:
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     includeNotices: true
 });
 ```
@@ -485,7 +513,7 @@ Defaults to `false`.
 Whether to include results with a type of `warning` in the Pa11y report. Issues with a type of `warning` are not directly actionable and so they are excluded by default. You can include them by using this option:
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     includeWarnings: true
 });
 ```
@@ -509,7 +537,7 @@ Defaults to `error`. Note this configuration is only available when using Pa11y 
 An object which implements the methods `debug`, `error`, and `info` which will be used to report errors and test information.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     log: {
         debug: console.log,
         error: console.error,
@@ -525,7 +553,7 @@ Each of these defaults to an empty function.
 The HTTP method to use when running Pa11y.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     method: 'POST'
 });
 ```
@@ -537,7 +565,7 @@ Defaults to `GET`.
 The HTTP POST data to send when running Pa11y. This should be combined with a `Content-Type` header. E.g to send form data:
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
     },
@@ -549,7 +577,7 @@ pa11y('http://example.com/', {
 Or to send JSON data:
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     headers: {
         'Content-Type': 'application/json'
     },
@@ -577,10 +605,11 @@ Defaults to `cli`. Note this configuration is only available when using Pa11y on
 The root element for testing a subset of the page opposed to the full document.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     rootElement: '#main'
 });
 ```
+
 Defaults to `null`, meaning the full document will be tested. If the specified root element isn't found, the full document will be tested.
 
 ### `runners` (array)
@@ -588,7 +617,7 @@ Defaults to `null`, meaning the full document will be tested. If the specified r
 An array of runner names which correspond to existing and installed [Pa11y runners](#runners). If a runner is not found then Pa11y will error.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     runners: [
         'axe',
         'htmlcs'
@@ -609,7 +638,7 @@ Defaults to:
 An array of WCAG 2.0 guidelines that you'd like to include to the current standard. You can find the codes for each guideline in the [HTML Code Sniffer WCAG2AAA ruleset][htmlcs-wcag2aaa-ruleset]. **Note:** only used by htmlcs runner.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     rules: [
         'Principle1.Guideline1_3.1_3_1_AAA'
     ]
@@ -621,7 +650,7 @@ pa11y('http://example.com/', {
 A file path to save a screen capture of the tested page to. The screen will be captured immediately after the Pa11y tests have run so that you can verify that the expected page was tested.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     screenCapture: `${__dirname}/my-screen-capture.png`
 });
 ```
@@ -633,7 +662,7 @@ Defaults to `null`, meaning the screen will not be captured. Note the directory 
 The accessibility standard to use when testing pages. This should be one of `WCAG2A`, `WCAG2AA`, or `WCAG2AAA`. **Note:** only used by htmlcs runner.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     standard: 'WCAG2A'
 });
 ```
@@ -659,7 +688,7 @@ The time in milliseconds that a test should be allowed to run before calling bac
 Please note that this is the timeout for the _entire_ test run (including time to initialise Chrome, load the page, and run the tests).
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     timeout: 500
 });
 ```
@@ -671,7 +700,7 @@ Defaults to `30000`.
 The `User-Agent` header to send with Pa11y requests. This is helpful to identify Pa11y in your logs.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     userAgent: 'A11Y TESTS'
 });
 ```
@@ -683,7 +712,7 @@ Defaults to `pa11y/<version>`.
 The viewport configuration. This can have any of the properties supported by the [puppeteer `setViewport` method][puppeteer-viewport].
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     viewport: {
         width: 320,
         height: 480,
@@ -707,21 +736,19 @@ Defaults to:
 The time in milliseconds to wait before running HTML CodeSniffer on the page.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     wait: 500
 });
 ```
 
 Defaults to `0`.
 
-
-Actions
--------
+## Actions
 
 Actions are additional interactions that you can make Pa11y perform before the tests are run. They allow you to do things like click on a button, enter a value in a form, wait for a redirect, or wait for the URL fragment to change:
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'click element #tab-1',
         'wait for element #tab-1-content to be visible',
@@ -745,12 +772,13 @@ Below is a reference of all the available actions and what they do on the page. 
 This allows you to click an element by passing in a CSS selector. This action takes the form `click element <selector>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'click element #tab-1'
     ]
 });
 ```
+
 You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector), including classes and types.
 
 ### Set Field Value
@@ -758,7 +786,7 @@ You can use any valid [query selector](https://developer.mozilla.org/en-US/docs/
 This allows you to set the value of a text-based input or select box by passing in a CSS selector and value. This action takes the form `set field <selector> to <value>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'set field #fullname to John Doe'
     ]
@@ -770,7 +798,7 @@ pa11y('http://example.com/', {
 This allows you to check or uncheck checkbox and radio inputs by passing in a CSS selector. This action takes the form `check field <selector>` or `uncheck field <selector>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'check field #terms-and-conditions',
         'uncheck field #subscribe-to-marketing'
@@ -783,7 +811,7 @@ pa11y('http://example.com/', {
 This allows you to capture the screen between other actions, useful to verify that the page looks as you expect before the Pa11y test runs. This action takes the form `screen capture <file-path>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'screen capture example.png'
     ]
@@ -794,17 +822,17 @@ pa11y('http://example.com/', {
 
 This allows you to pause the test until a condition is met, and the page has either a given fragment, path, or URL. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. You can also wait until the page does **not** have a given fragment, path, or URL using the `to not be` syntax. This action takes one of the forms:
 
-  - `wait for fragment to be <fragment>` (including the preceding `#`)
-  - `wait for fragment to not be <fragment>` (including the preceding `#`)
-  - `wait for path to be <path>` (including the preceding `/`)
-  - `wait for path to not be <path>` (including the preceding `/`)
-  - `wait for url to be <url>`
-  - `wait for url to not be <url>`
+* `wait for fragment to be <fragment>` (including the preceding `#`)
+* `wait for fragment to not be <fragment>` (including the preceding `#`)
+* `wait for path to be <path>` (including the preceding `/`)
+* `wait for path to not be <path>` (including the preceding `/`)
+* `wait for url to be <url>`
+* `wait for url to not be <url>`
 
 E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'click element #login-link',
         'wait for path to be /login'
@@ -816,15 +844,15 @@ pa11y('http://example.com/', {
 
 This allows you to pause the test until an element on the page (matching a CSS selector) is either added, removed, visible, or hidden. This will wait until Pa11y times out so it should be used after another action that would trigger the change in state. This action takes one of the forms:
 
-  - `wait for element <selector> to be added`
-  - `wait for element <selector> to be removed`
-  - `wait for element <selector> to be visible`
-  - `wait for element <selector> to be hidden`
+* `wait for element <selector> to be added`
+* `wait for element <selector> to be removed`
+* `wait for element <selector> to be visible`
+* `wait for element <selector> to be hidden`
 
 E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'click element #tab-2',
         'wait for element #tab-1 to be hidden'
@@ -837,7 +865,7 @@ pa11y('http://example.com/', {
 This allows you to pause the test until an element on the page (matching a CSS selector) emits an event. This will wait until Pa11y times out so it should be used after another action that would trigger the event. This action takes the form `wait for element <selector> to emit <event-type>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
         'click element #tab-2',
         'wait for element #tab-panel-to to emit content-loaded'
@@ -850,31 +878,29 @@ pa11y('http://example.com/', {
 This action allows you to navigate to a new URL if, for example, the URL is inaccessible using other methods. This action takes the form `navigate to <url>`. E.g.
 
 ```js
-pa11y('http://example.com/', {
+pa11y('https://example.com/', {
     actions: [
-        'navigate to http://another-example.com'
+        'navigate to https://another-example.com'
     ]
 });
 ```
 
-
-Runners
--------
+## Runners
 
 Pa11y supports multiple test runners which return different results. The built-in test runners are:
 
-  - `axe`: run tests using [aXe-core][axe].
-  - `htmlcs` (default): run tests using [HTML CodeSniffer][htmlcs]
+* `axe`: run tests using [aXe-core][axe].
+* `htmlcs` (default): run tests using [HTML CodeSniffer][htmlcs]
 
 You can also write and publish your own runners. Pa11y looks for runners in your `node_modules` folder (with a naming pattern), and the current working directory. The first runner found will be loaded. So with this command:
 
-```
-pa11y --runner my-testing-tool http://example.com
+```sh
+pa11y --runner my-testing-tool https://example.com
 ```
 
 The following locations will be checked:
 
-```
+```sh
 <cwd>/node_modules/pa11y-runner-my-testing-tool
 <cwd>/node_modules/my-testing-tool
 <cwd>/my-testing-tool
@@ -900,10 +926,10 @@ The `run` method _must not_ use anything that's been imported using `require`, a
 
 The `run` method is called with two arguments:
 
-  - `options`: Options specified in the test runner
-  - `pa11y`: The Pa11y test runner, which includes some helper methods:
-    - `pa11y.getElementContext(element)`: Get a short HTML context snippet for an element
-    - `pa11y.getElementSelector(element)`: Get a unique selector with which you can select this element in a page
+* `options`: Options specified in the test runner
+* `pa11y`: The Pa11y test runner, which includes some helper methods:
+  * `pa11y.getElementContext(element)`: Get a short HTML context snippet for an element
+  * `pa11y.getElementSelector(element)`: Get a unique selector with which you can select this element in a page
 
 The `run` method _must_ resolve with an array of Pa11y issues. These follow the format:
 
@@ -917,9 +943,7 @@ The `run` method _must_ resolve with an array of Pa11y issues. These follow the 
 }
 ```
 
-
-Examples
---------
+## Examples
 
 ### Basic Example
 
@@ -937,31 +961,21 @@ Step through some actions before Pa11y runs. This example logs into a fictional 
 
 Pass in pre-created Puppeteer browser and page instances so that you can reuse them between tests. [See the example](example/puppeteer/index.js).
 
-
-Common Questions and Troubleshooting
-------------------------------------
+## Common Questions and Troubleshooting
 
 See our [Troubleshooting guide](TROUBLESHOOTING.md) to get the answers to common questions about Pa11y, along with some ideas to help you troubleshoot any problems.
 
+## Tutorials and articles
 
-Tutorials and articles
-------------------------------------
+You can find some useful tutorials and articles in the [Tutorials section](https://pa11y.org/tutorials/) of [pa11y.org](https://pa11y.org/).
 
-Here are some useful articles written by Pa11y users and contributors:
-
-- [Accessibility Testing with Pa11y](https://bitsofco.de/pa11y/)
-- [Using actions in Pa11y](http://hollsk.co.uk/posts/view/using-actions-in-pa11y)
-- [Introduction to Accessibility Testing With Pa11y](http://cruft.io/posts/accessibility-testing-with-pa11y/)
-
-
-Contributing
-------------
+## Contributing
 
 There are many ways to contribute to Pa11y, we cover these in the [contributing guide](CONTRIBUTING.md) for this repo.
 
 If you're ready to contribute some code, clone this repo locally and commit your code on a new branch.
 
-Please write unit tests for your code, and check that everything works by running the following before opening a <abbr title="pull request">PR</abbr>:
+Please write unit tests for your code, and check that everything works by running the following before opening a pull request:
 
 ```sh
 npm run lint
@@ -980,8 +994,7 @@ npm run test-integration    # Run the integration tests
 
 To debug a test file you need to ensure that [setup.test.js](test/integration/setup.test.js) is ran before the test file. This adds a `before/each` to start and stop the integration test server.
 
-Support and Migration
----------------------
+## Support and Migration
 
 Pa11y major versions are normally supported for 6 months after their last minor release. This means that patch-level changes will be added and bugs will be fixed. The table below outlines the end-of-support dates for major versions, and the last minor release for that version.
 
@@ -989,7 +1002,8 @@ We also maintain a [migration guide](MIGRATION.md) to help you migrate.
 
 | :grey_question: | Major Version | Last Minor Release | Node.js Versions | Support End Date |
 | :-------------- | :------------ | :----------------- | :--------------- | :--------------- |
-| :heart:         | 5             | N/A                | 8+               | N/A              |
+| :heart:         | 6             | N/A                | 12+              | N/A              |
+| :warning:       | 5             | 5.3                | 8+               | 2021-11-25       |
 | :skull:         | 4             | 4.13               | 4–8              | 2018-08-15       |
 | :skull:         | 3             | 3.8                | 0.12–6           | 2016-12-05       |
 | :skull:         | 2             | 2.4                | 0.10–0.12        | 2016-10-16       |
@@ -997,19 +1011,21 @@ We also maintain a [migration guide](MIGRATION.md) to help you migrate.
 
 If you're opening issues related to these, please mention the version that the issue relates to.
 
-License
--------
+## License
 
-Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].<br/>
-Copyright &copy; 2013–2019, Team Pa11y and contributors
+Pa11y is licensed under the [Lesser General Public License (LGPL-3.0)][info-license].  
+Copyright &copy; 2013–2021, Team Pa11y and contributors
 
-[1.0-json-reporter]: https://github.com/pa11y/reporter-1.0-json
-[4.x]: https://github.com/pa11y/pa11y/tree/4.x
-[async]: https://github.com/caolan/async
+[5.x]: https://github.com/pa11y/pa11y/tree/5.x
 [axe]: https://www.axe-core.org/
-[brew]: http://mxcl.github.com/homebrew/
+[brew]: https://mxcl.github.com/homebrew/
 [htmlcs-wcag2aaa-ruleset]: https://github.com/pa11y/pa11y/wiki/HTML-CodeSniffer-Rules
-[node]: http://nodejs.org/
+[htmlcs]: https://squizlabs.github.io/HTML_CodeSniffer/
+[info-build]: https://github.com/pa11y/pa11y.github.io/actions/workflows/build-and-test.yml
+[info-license]: LICENSE
+[info-node]: package.json
+[info-npm]: https://www.npmjs.com/package/pa11y
+[node]: https://nodejs.org/
 [npm]: https://www.npmjs.com/
 [nvm]: https://github.com/nvm-sh/nvm
 [promise]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
@@ -1018,15 +1034,7 @@ Copyright &copy; 2013–2019, Team Pa11y and contributors
 [puppeteer-page]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page
 [puppeteer-viewport]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport
 [semver range]: https://github.com/npm/node-semver#ranges
-[sidekick-proposal]: https://github.com/pa11y/sidekick/blob/master/PROPOSAL.md
-[htmlcs]: https://squizlabs.github.io/HTML_CodeSniffer/
-[windows-install]: https://github.com/TooTallNate/node-gyp#installation
-
-[info-license]: LICENSE
-[info-node]: package.json
-[info-npm]: https://www.npmjs.com/package/pa11y
-[info-build]: https://travis-ci.org/pa11y/pa11y
+[shield-build]: https://github.com/pa11y/pa11y/actions/workflows/build-and-test.yml/badge.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-node]: https://img.shields.io/node/v/pa11y.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y.svg
-[shield-build]: https://img.shields.io/travis/pa11y/pa11y/master.svg


### PR DESCRIPTION
* Add extended TOC
* Remove `beta` label from and notice
* Format all headings in the same way
* Format all lists in the same way
* Unify the Node.js installation instructions for Linux and macOS for simplicity
* Remove Node.js installation instructions for Windows 7
* Update support table
* Replace HTTP with HTTPS throughout the whole document
* Replace the links in the tutorials section with a link to the tutorial page where we have more resources
* Add language to all code blocks
* Remove unused reference to JSON reporter 1.0
* Update build status badge and info
* Update copyright year