### PR TITLE
Handles null context in csv reporter

### DIFF
--- a/lib/reporters/csv.js
+++ b/lib/reporters/csv.js
@@ -14,11 +14,13 @@ report.results = results => {
 
 // Internal method used to report an individual CSV row
 report.row = issue => {
+	const context = issue.context === null ? '' : issue.context;
+
 	return [
 		JSON.stringify(issue.type),
 		JSON.stringify(issue.code),
 		JSON.stringify(issue.message),
-		JSON.stringify(issue.context),
+		JSON.stringify(context),
 		JSON.stringify(issue.selector)
 	].join(',');
 };

--- a/test/integration/cli/reporter-csv.test.js
+++ b/test/integration/cli/reporter-csv.test.js
@@ -23,7 +23,7 @@ describe('CLI reporter CSV', function() {
 			assert.lengthEquals(lines, 29);
 			assert.strictEqual(lines[0], '"type","code","message","context","selector"');
 			lines.slice(1).forEach(line => {
-				assert.match(line, /^"(error|warning|notice)","[^"]+","[^"]+",(".*"|null),"[^"]*"$/i);
+				assert.match(line, /^"(error|warning|notice)","[^"]+","[^"]+",(".*"),"[^"]*"$/i);
 			});
 		});
 


### PR DESCRIPTION
Handles when HTML_CodeSniffer returns null for the context (with the newer `npm` version) and returns an empty string instead.

Fixes https://github.com/pa11y/pa11y-reporter-csv/issues/1