### PR TITLE
Update --environment CLI output to include pa11y version

### DIFF
--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -309,11 +309,9 @@ function collectOptions(val, array) {
 async function outputEnvironmentInfo() {
 	const envData = await envinfo.run({
 		System: ['OS', 'CPU', 'Memory', 'Shell'],
-		Binaries: ['Node', 'Yarn', 'npm'],
-		npmPackages: ['pa11y']
+		Binaries: ['Node', 'Yarn', 'npm']
 	});
-
-	console.log(envData);
+	console.log(`${envData}  pa11y: ${pkg.version}\n`);
 	process.exit(0);
 }
 

--- a/test/integration/cli/environment.test.js
+++ b/test/integration/cli/environment.test.js
@@ -18,12 +18,13 @@ describe('CLI environment', function() {
 		assert.strictEqual(pa11yResponse.exitCode, 0);
 	});
 
-	it('respondes with information about the user\'s environment', function() {
+	it('responds with information about the user\'s environment', function() {
 		assert.match(pa11yResponse.output, /OS/);
 		assert.match(pa11yResponse.output, /CPU/);
 		assert.match(pa11yResponse.output, /Memory/);
 		assert.match(pa11yResponse.output, /Node/);
 		assert.match(pa11yResponse.output, /npm/);
+		assert.match(pa11yResponse.output, /pa11y/);
 	});
 
 });


### PR DESCRIPTION
This updates the `--environment` CLI output to include the actual `pa11y` version from package.json, and updates the corresponding integration test to check for pa11y output (closes #577).