### PR TITLE
576: improve detection of local file paths

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -412,24 +412,37 @@ function verifyOptions(options) {
 }
 
 /**
- * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period,
- * it will be resolved as a path against the current working directory. If the URL does
- * begin with a scheme, it will be prepended with "http://".
+ * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period
+ * or it is a valid path relative to the current directory, it will be resolved as a
+ * path against the current working directory. If the URL does begin with a scheme, it
+ * will be prepended with "http://".
  * @private
  * @param {String} url - The URL to sanitize.
  * @returns {String} Returns the sanitized URL.
  */
 function sanitizeUrl(url) {
-	if (/^\//i.test(url)) {
-		return `file://${url}`;
+	let sanitizedUrl = url;
+	if (/^[./]/i.test(url) || fileExists(url)) {
+		sanitizedUrl = `file://${path.resolve(process.cwd(), url)}`;
+	} else if (!/^(https?|file):\/\//i.test(url)) {
+		sanitizedUrl = `http://${url}`;
 	}
-	if (/^\./i.test(url)) {
-		return `file://${path.resolve(process.cwd(), url)}`;
+	return sanitizedUrl;
+}
+
+/**
+ * Check whether a file exists on a given path without regard to permissions
+ * @private
+ * @param {String} filePath - the path to check
+ * @returns {Boolean} true if file exists, false if not
+ */
+function fileExists(filePath) {
+	try {
+		fs.accessSync(filePath, fs.constants.F_OK);
+		return true;
+	} catch (error) {
+		return false;
 	}
-	if (!/^(https?|file):\/\//i.test(url)) {
-		return `http://${url}`;
-	}
-	return url;
 }
 
 /**


### PR DESCRIPTION
Addresses #576 
uses `fs.accessSync` to check for existence of a file path on provided url if the url does not begin with "." or "/".
If path exists, the `file://` protocol will be used.  Otherwise it will attempt to use `http://`.