### PR TITLE
576: check local paths when parsing options

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const extend = require('node.extend');
+const fs = require('fs');
 const path = require('path');
 
 module.exports.parseArguments = parseArguments;
@@ -79,22 +80,35 @@ function defaultOptions(options, defaults) {
 }
 
 /**
- * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period,
- * it will be resolved as a path against the current working directory. If the URL does
- * begin with a scheme, it will be prepended with "http://".
+ * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period
+ * or it is a valid path relative to the current directory, it will be resolved as a
+ * path against the current working directory. If the URL does begin with a scheme, it
+ * will be prepended with "http://".
  * @private
  * @param {String} url - The URL to sanitize.
  * @returns {String} Returns the sanitized URL.
  */
 function sanitizeUrl(url) {
-	if (/^\//i.test(url)) {
-		return `file://${url}`;
+	let sanitizedUrl = url;
+	if (/^[./]/i.test(url) || fileExists(url)) {
+		sanitizedUrl = `file://${path.resolve(process.cwd(), url)}`;
+	} else if (!/^(https?|file):\/\//i.test(url)) {
+		sanitizedUrl = `http://${url}`;
 	}
-	if (/^\./i.test(url)) {
-		return `file://${path.resolve(process.cwd(), url)}`;
+	return sanitizedUrl;
+}
+
+/**
+ * Check whether a file exists on a given path without regard to permissions
+ * @private
+ * @param {String} filePath - the path to check
+ * @returns {Boolean} true if file exists, false if not
+ */
+function fileExists(filePath) {
+	try {
+		fs.accessSync(filePath, fs.constants.F_OK);
+		return true;
+	} catch (error) {
+		return false;
 	}
-	if (!/^(https?|file):\/\//i.test(url)) {
-		return `http://${url}`;
-	}
-	return url;
 }

--- a/lib/option.js
+++ b/lib/option.js
@@ -90,25 +90,10 @@ function defaultOptions(options, defaults) {
  */
 function sanitizeUrl(url) {
 	let sanitizedUrl = url;
-	if (/^[./]/i.test(url) || fileExists(url)) {
+	if (/^[./]/i.test(url) || fs.existsSync(url)) {
 		sanitizedUrl = `file://${path.resolve(process.cwd(), url)}`;
 	} else if (!/^(https?|file):\/\//i.test(url)) {
 		sanitizedUrl = `http://${url}`;
 	}
 	return sanitizedUrl;
-}
-
-/**
- * Check whether a file exists on a given path without regard to permissions
- * @private
- * @param {String} filePath - the path to check
- * @returns {Boolean} true if file exists, false if not
- */
-function fileExists(filePath) {
-	try {
-		fs.accessSync(filePath, fs.constants.F_OK);
-		return true;
-	} catch (error) {
-		return false;
-	}
 }

--- a/test/unit/mock/fs.mock.js
+++ b/test/unit/mock/fs.mock.js
@@ -3,5 +3,6 @@
 const sinon = require('sinon');
 
 module.exports = {
+	existsSync: sinon.stub(),
 	readFileSync: sinon.stub()
 };


### PR DESCRIPTION
Per #576 attempting to detect valid local paths before deciding to use `http://` scheme

Changed some style and coverage within tests as well. I do not believe that `options` needs to be re-required within the test, and in fact we can import the functions we need directly, just once.