### PR TITLE
Draft: Fix README to reflect html reporter merged into pa11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,9 @@ The command-line tool can report test results in a few different ways using the 
 
 * `cli`: output test results in a human-readable format
 * `csv`: output test results as comma-separated values
+* `html`: output test results as an HTML page
 * `json`: output test results as a JSON array
 * `tsv`: output test results as tab-separated values
-
-The Pa11y team maintain an additional [`html`](https://github.com/pa11y/pa11y-reporter-html) reporter that can be installed separately via `npm` and can be used as an example of how to build more complex reporters.
 
 You can also write and publish your own reporters. Pa11y looks for reporters in your `node_modules` folder (with a naming pattern), and the current working directory. The first reporter found will be loaded. So with this command:
 


### PR DESCRIPTION
The HTML reporter was merged into pa11y in https://github.com/pa11y/pa11y/pull/599, but the README still lists it as a separate module.