### PR TITLE
HTML reporter fix and reporter integration test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,9 @@ The command-line tool can report test results in a few different ways using the 
 
 * `cli`: output test results in a human-readable format
 * `csv`: output test results as comma-separated values
+* `html`: output test results as an HTML page
 * `json`: output test results as a JSON array
 * `tsv`: output test results as tab-separated values
-
-The Pa11y team maintain an additional [`html`](https://github.com/pa11y/pa11y-reporter-html) reporter that can be installed separately via `npm` and can be used as an example of how to build more complex reporters.
 
 You can also write and publish your own reporters. Pa11y looks for reporters in your `node_modules` folder (with a naming pattern), and the current working directory. The first reporter found will be loaded. So with this command:
 

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -199,7 +199,7 @@ function loadReporter(name) {
 	let reporterMethods;
 
 	try {
-		if (['json', 'cli', 'csv', 'tsv'].includes(name)) {
+		if (['json', 'cli', 'csv', 'tsv', 'html'].includes(name)) {
 			reporterMethods = require(`../lib/reporters/${name}`);
 		} else {
 			reporterMethods = requireFirst([

--- a/test/integration/cli/reporter-cli.test.js
+++ b/test/integration/cli/reporter-cli.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('proclaim');
+const runPa11yCli = require('../helper/pa11y-cli');
+
+describe('CLI reporter CLI', function() {
+	let pa11yResponse;
+
+	describe('when the `--reporter` flag is set to "cli"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--reporter', 'cli'
+				]
+			});
+		});
+
+		it('outputs issues to CLI', function() {
+			assert.match(pa11yResponse.stdout, /^Results for URL: .*\/errors$/im);
+			assert.match(pa11yResponse.stdout, /^.*Error: .*$/im);
+			assert.match(pa11yResponse.stdout, /^1 Errors$/im);
+		});
+
+	});
+
+	describe('when the `reporter` config is set to "cli"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--config', './mock/config/reporter-cli.json'
+				]
+			});
+		});
+
+		it('outputs issues to CLI', function() {
+			assert.match(pa11yResponse.stdout, /^Results for URL: .*\/errors$/im);
+			assert.match(pa11yResponse.stdout, /^.*Error: .*$/im);
+			assert.match(pa11yResponse.stdout, /^1 Errors$/im);
+		});
+
+	});
+
+});

--- a/test/integration/cli/reporter-csv.test.js
+++ b/test/integration/cli/reporter-csv.test.js
@@ -29,4 +29,27 @@ describe('CLI reporter CSV', function() {
 
 	});
 
+	describe('when the `--reporter` config is set to "csv"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--include-notices',
+					'--include-warnings',
+					'--config', './mock/config/reporter-csv.json'
+				]
+			});
+		});
+
+		it('outputs issues in CSV format', function() {
+			const lines = pa11yResponse.stdout.trim().split('\n');
+			assert.lengthEquals(lines, 29);
+			assert.strictEqual(lines[0], '"type","code","message","context","selector"');
+			lines.slice(1).forEach(line => {
+				assert.match(line, /^"(error|warning|notice)","[^"]+","[^"]+",(".*"),"[^"]*"$/i);
+			});
+		});
+
+	});
+
 });

--- a/test/integration/cli/reporter-html.test.js
+++ b/test/integration/cli/reporter-html.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('proclaim');
+const runPa11yCli = require('../helper/pa11y-cli');
+
+describe('CLI reporter HTML', function() {
+	let pa11yResponse;
+
+	describe('when the `--reporter` flag is set to "html"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--reporter', 'html'
+				]
+			});
+		});
+
+		it('outputs issues in HTML format', function() {
+			assert.include(pa11yResponse.stdout,
+				`<h1>Accessibility Report For "${global.mockWebsiteAddress}/errors"</h1>`);
+		});
+
+	});
+
+	describe('when the `reporter` config is set to "html"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--config', './mock/config/reporter-html.json'
+				]
+			});
+		});
+
+		it('outputs issues in HTML format', function() {
+			assert.include(pa11yResponse.stdout,
+				`<h1>Accessibility Report For "${global.mockWebsiteAddress}/errors"</h1>`);
+		});
+
+	});
+
+});

--- a/test/integration/cli/reporter-html.test.js
+++ b/test/integration/cli/reporter-html.test.js
@@ -19,6 +19,8 @@ describe('CLI reporter HTML', function() {
 		it('outputs issues in HTML format', function() {
 			assert.include(pa11yResponse.stdout,
 				`<h1>Accessibility Report For "${global.mockWebsiteAddress}/errors"</h1>`);
+			assert.match(pa11yResponse.stdout, /<span.*>1 errors<\/span>/);
+			assert.match(pa11yResponse.stdout, /<h2>Error:[^<]*<\/h2>/);
 		});
 
 	});
@@ -36,6 +38,8 @@ describe('CLI reporter HTML', function() {
 		it('outputs issues in HTML format', function() {
 			assert.include(pa11yResponse.stdout,
 				`<h1>Accessibility Report For "${global.mockWebsiteAddress}/errors"</h1>`);
+			assert.match(pa11yResponse.stdout, /<span.*>1 errors<\/span>/);
+			assert.match(pa11yResponse.stdout, /<h2>Error:[^<]*<\/h2>/);
 		});
 
 	});

--- a/test/integration/cli/reporter-tsv.test.js
+++ b/test/integration/cli/reporter-tsv.test.js
@@ -23,7 +23,7 @@ describe('CLI reporter TSV', function() {
 			assert.lengthEquals(lines, 29);
 			assert.strictEqual(lines[0], '"type"\t"code"\t"message"\t"context"\t"selector"');
 			lines.slice(1).forEach(line => {
-				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*")\t"[^"]*"$/i);
+				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*"|null)\t"[^"]*"$/i);
 			});
 		});
 
@@ -46,7 +46,7 @@ describe('CLI reporter TSV', function() {
 			assert.lengthEquals(lines, 29);
 			assert.strictEqual(lines[0], '"type"\t"code"\t"message"\t"context"\t"selector"');
 			lines.slice(1).forEach(line => {
-				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*")\t"[^"]*"$/i);
+				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*"|null)\t"[^"]*"$/i);
 			});
 		});
 

--- a/test/integration/cli/reporter-tsv.test.js
+++ b/test/integration/cli/reporter-tsv.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('proclaim');
+const runPa11yCli = require('../helper/pa11y-cli');
+
+describe('CLI reporter TSV', function() {
+	let pa11yResponse;
+
+	describe('when the `--reporter` flag is set to "tsv"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--include-notices',
+					'--include-warnings',
+					'--reporter', 'tsv'
+				]
+			});
+		});
+
+		it('outputs issues in TSV format', function() {
+			const lines = pa11yResponse.stdout.trim().split('\n');
+			assert.lengthEquals(lines, 29);
+			assert.strictEqual(lines[0], '"type"\t"code"\t"message"\t"context"\t"selector"');
+			lines.slice(1).forEach(line => {
+				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*")\t"[^"]*"$/i);
+			});
+		});
+
+	});
+
+	describe('when the `--reporter` config is set to "tsv"', function() {
+
+		before(async function() {
+			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+				arguments: [
+					'--include-notices',
+					'--include-warnings',
+					'--config', './mock/config/reporter-tsv.json'
+				]
+			});
+		});
+
+		it('outputs issues in TSV format', function() {
+			const lines = pa11yResponse.stdout.trim().split('\n');
+			assert.lengthEquals(lines, 29);
+			assert.strictEqual(lines[0], '"type"\t"code"\t"message"\t"context"\t"selector"');
+			lines.slice(1).forEach(line => {
+				assert.match(line, /^"(error|warning|notice)"\t"[^"]+"\t"[^"]+"\t(".*")\t"[^"]*"$/i);
+			});
+		});
+
+	});
+
+});

--- a/test/integration/mock/config/reporter-cli.json
+++ b/test/integration/mock/config/reporter-cli.json
@@ -1,0 +1,3 @@
+{
+	"reporter": "cli"
+}

--- a/test/integration/mock/config/reporter-csv.json
+++ b/test/integration/mock/config/reporter-csv.json
@@ -1,0 +1,3 @@
+{
+	"reporter": "csv"
+}

--- a/test/integration/mock/config/reporter-html.json
+++ b/test/integration/mock/config/reporter-html.json
@@ -1,0 +1,3 @@
+{
+	"reporter": "html"
+}

--- a/test/integration/mock/config/reporter-tsv.json
+++ b/test/integration/mock/config/reporter-tsv.json
@@ -1,0 +1,3 @@
+{
+	"reporter": "tsv"
+}


### PR DESCRIPTION
Closes #615 

- Update README for HTML reporter
- Add `html` reporter CLI option to [`loadReporters`](https://github.com/pa11y/pa11y/blob/60cde76db60431753b8258dfd6be4bf55c98463f/bin/pa11y.js#L202) 
- Update csv reporter integration test to include config case
- Add integration tests for TSV reporter option
- Add integration tests for HTML reporter option
- Add integration tests for CLI reporter option
