### PR TITLE
chore(lib): fix app runtime required modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,7 +1430,8 @@
     "commander": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
-      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "axe-core": "~4.2.1",
     "bfj": "~7.0.2",
-    "commander": "~8.0.0",
     "envinfo": "~7.8.1",
     "hogan.js": "~3.0.2",
     "html_codesniffer": "~2.5.1",
@@ -45,6 +44,7 @@
     "semver": "~7.3.5"
   },
   "devDependencies": {
+    "commander": "~8.0.0",
     "eslint": "^7.27.0",
     "eslint-plugin-jest": "^25.3.4",
     "jest": "^27.4.7",


### PR DESCRIPTION
1. fix required runtime modules for library. Commander is only for the cli via bin. 