### PR TITLE
Support macOS and Windows (absorb `next`)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,3 @@
-name: Build and lint
-
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ on:
       - '**'
 
 jobs:
-  checkout_and_test:
-    name: Node v${{ matrix.node-version }} on ${{ matrix.os }}
+  test:
+    name: Lint and test on ${{ matrix.os }} with Node.js ${{ matrix.node-version }} 
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,11 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests.
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Build and lint
 
 on:
   push:
-    branches: # Run actions when code is committed to these branches
+    branches:
       - master
   pull_request:
-    branches: # Run actions when a PR is pushed based on one of these branches
+    branches:
       - '**'
 
 jobs:
@@ -26,15 +23,10 @@ jobs:
         run: |
           git config --global core.autocrlf false
         if: runner.os == 'Windows'
-      - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v3
-      - name: Setup node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Run linter
-        run: npm run lint
-      - name: Run tests
-        run: npm test
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,27 +9,29 @@ on:
       - master
   pull_request:
     branches: # Run actions when a PR is pushed based on one of these branches
-      - master
-      - 1.x
-      - 2.x
-      - 3.x
-      - 4.x
-      - 5.x
-      - 5.2.x
+      - '**'
 
 jobs:
   checkout_and_test:
-    runs-on: ubuntu-latest
+    name: Node v${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         node-version: [18, 20]
     steps:
+      - name: Set git config
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+        if: runner.os == 'Windows'
       - name: Checkout code from ${{ github.repository }}
-        uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v3
+      - name: Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm ci
       - name: Run linter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         node-version: [18, 20]
     steps:
-      - name: Set git config
+      - name: Normalise line-ending handling in Git
         shell: bash
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,6 @@ on:
       - main
       - master
   pull_request:
-    branches:
-      - '**'
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   checkout_and_test:
-    name: Node v${{ matrix.node }} on ${{ matrix.os }}
+    name: Node v${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,10 +28,10 @@ jobs:
         if: runner.os == 'Windows'
       - name: Checkout code from ${{ github.repository }}
         uses: actions/checkout@v3
-      - name: Setup node ${{ matrix.node }}
+      - name: Setup node ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
       - name: Run linter

--- a/lib/option.js
+++ b/lib/option.js
@@ -80,17 +80,21 @@ function defaultOptions(options, defaults) {
 }
 
 /**
- * Sanitize a URL, ensuring it has a scheme. If the URL begins with a slash or a period
- * or it is a valid path relative to the current directory, it will be resolved as a
- * path against the current working directory. If the URL does begin with a scheme, it
- * will be prepended with "http://".
+ * Sanitize a URL, ensuring it has a scheme. If the URL begins with a period or it
+ * is a valid path relative to the current directory, it is assumed to be a file path
+ * and is resolved relative to the current working directory. If it is an absolute
+ * file path, that file path is used. If the URL does begin with a scheme, it will
+ * be prepended with "http://".
  * @private
  * @param {String} url - The URL to sanitize.
  * @returns {String} Returns the sanitized URL.
  */
 function sanitizeUrl(url) {
 	let sanitizedUrl = url;
-	if (/^[./]/i.test(url) || fs.existsSync(url)) {
+	if (/^[.]/i.test(url) || path.isAbsolute(url) || fs.existsSync(url)) {
+		// This works for absolute paths since path.resolve starts at the right and
+		// works left, stopping once it has an absolute path. So, if the URL is an
+		// absolute path it is returned.
 		sanitizedUrl = `file://${path.resolve(process.cwd(), url)}`;
 	} else if (!/^(https?|file):\/\//i.test(url)) {
 		sanitizedUrl = `http://${url}`;

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -3,6 +3,7 @@
 const runAction = require('./action');
 const option = require('./option');
 const fs = require('fs');
+const path = require('path');
 const pkg = require('../package.json');
 const promiseTimeout = require('p-timeout');
 const puppeteer = require('puppeteer');
@@ -123,7 +124,7 @@ async function setBrowser(options, state) {
 	if (options.browser) {
 		options.log.debug(
 			'Using a pre-configured Headless Chrome instance, ' +
-					'the `chromeLaunchConfig` option will be ignored'
+			'the `chromeLaunchConfig` option will be ignored'
 		);
 		state.browser = options.browser;
 		state.autoClose = false;
@@ -283,7 +284,7 @@ async function injectRunners(options, state) {
 	// We only load these files once on the first run of Pa11y as they don't
 	// change between runs
 	if (!runnersJavascript.pa11y) {
-		runnersJavascript.pa11y = fs.readFileSync(`${__dirname}/runner.js`, 'utf-8');
+		runnersJavascript.pa11y = fs.readFileSync(path.join(__dirname, 'runner.js'), 'utf-8');
 	}
 
 	for (const runner of options.runners) {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "lint": "eslint .",
     "test-unit": "jest test/unit",
     "test-coverage": "jest test/unit --coverage",
-    "test-integration": "MOCK_SERVER_PORT=8081 jest test/integration",
-    "test": "MOCK_SERVER_PORT=8081 jest --coverage"
+    "test-integration": "jest test/integration",
+    "test": "jest --coverage"
   },
   "files": [
     "bin",

--- a/test/integration/global-setup.js
+++ b/test/integration/global-setup.js
@@ -2,6 +2,10 @@
 
 const startMockWebsite = require('./mock/website');
 
+// Set here because this runs before setup-env and is require to start server.
+// Saved as environment variable for use in setup-env in case not set.
+process.env.MOCK_SERVER_PORT = process.env.MOCK_SERVER_PORT || 8081;
+
 module.exports = async () => {
 	global.mockWebsite = await startMockWebsite(process.env.MOCK_SERVER_PORT);
 	// 		Global.mockWebsiteAddress = `http://localhost:${global.SERVER_PORT}`;

--- a/test/integration/helper/pa11y-cli.js
+++ b/test/integration/helper/pa11y-cli.js
@@ -20,7 +20,7 @@ function runPa11yCli(url, options = {}) {
 	options.arguments.push(url);
 
 	return new Promise((resolve, reject) => {
-		const binPath = path.resolve(`${__dirname}/../../../bin/pa11y.js`);
+		const binFile = path.resolve(__dirname, '../../../bin/pa11y.js');
 
 		const response = {
 			exitCode: '',
@@ -30,7 +30,7 @@ function runPa11yCli(url, options = {}) {
 			stdout: ''
 		};
 
-		const pa11yProcess = spawn(binPath, options.arguments, {
+		const pa11yProcess = spawn('node', [binFile, ...options.arguments], {
 			cwd: options.workingDirectory,
 			env: options.environment
 		});

--- a/test/integration/mock/website.js
+++ b/test/integration/mock/website.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const http = require('http');
+const path = require('path');
 const parseUrl = require('url').parse;
 
 module.exports = startMockWebsite;
@@ -29,7 +30,8 @@ function createMockWebsite() {
 		request.on('end', () => {
 			const url = parseUrl(request.url).pathname;
 			try {
-				let html = fs.readFileSync(`${__dirname}/html/${url}.html`, 'utf-8');
+				const viewPath = path.join(__dirname, 'html', `${url}.html`);
+				let html = fs.readFileSync(viewPath, 'utf-8');
 				html = html.replace('{foo-header}', request.headers.foo);
 				html = html.replace('{bar-header}', request.headers.bar);
 				html = html.replace('{method}', request.method);

--- a/test/integration/setup-env.js
+++ b/test/integration/setup-env.js
@@ -1,4 +1,4 @@
 'use strict';
 
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 global.mockWebsiteAddress = `http://localhost:${process.env.MOCK_SERVER_PORT}`;

--- a/test/unit/lib/option.test.js
+++ b/test/unit/lib/option.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const	{parseArguments, verifyOptions} = require('../../../lib/option');
+const {parseArguments, verifyOptions} = require('../../../lib/option');
 
 describe('lib/option', () => {
 	const noop = () => { /* No-op */ };
@@ -216,13 +216,15 @@ describe('lib/option', () => {
 			});
 		});
 
-		describe('when `url` does not have a scheme and starts with a slash', () => {
+		describe('when `url` does not have a scheme and is an absolute path', () => {
+			const absolutePath = path.resolve(process.cwd(), './mock-path');
+
 			beforeEach(() => {
-				[url, options, callback] = parseArguments('/mock-path', {}, {});
+				[url, options, callback] = parseArguments(absolutePath, {}, {});
 			});
 
 			it('navigates to `url` with a `file` scheme added', () => {
-				expect(url).toEqual('file:///mock-path');
+				expect(url).toEqual(`file://${absolutePath}`);
 			});
 		});
 

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -225,14 +225,16 @@ describe('lib/pa11y', () => {
 
 		});
 
-		describe('when `url` does not have a scheme and starts with a slash', () => {
+		describe('when `url` does not have a scheme and is an absolute path', () => {
+			const absolutePath = path.resolve(process.cwd(), './mock-path');
+
 			beforeEach(async () => {
-				await pa11y('/mock-path');
+				await pa11y(absolutePath);
 			});
 
 			it('navigates to `url` with an `file` scheme added', () => {
 				expect(puppeteer.mockPage.goto).toHaveBeenCalledTimes(1);
-				expect(puppeteer.mockPage.goto).toHaveBeenCalledWith('file:///mock-path', expect.anything());
+				expect(puppeteer.mockPage.goto).toHaveBeenCalledWith(`file://${absolutePath}`, expect.anything());
 			});
 
 		});

--- a/test/unit/lib/runners/htmlcs.test.js
+++ b/test/unit/lib/runners/htmlcs.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const runner = require('../../../../lib/runners/htmlcs');
 
 describe('lib/runners/htmlcs', () => {
@@ -60,7 +61,7 @@ describe('lib/runners/htmlcs', () => {
 		expect(runner.scripts).toHaveLength(1);
 		expect(
 			runner.scripts[0].endsWith(
-				'node_modules/html_codesniffer/build/HTMLCS.js'
+				path.join('node_modules', 'html_codesniffer', 'build', 'HTMLCS.js')
 			)
 		).toEqual(true);
 	});


### PR DESCRIPTION
This PR merges the changes already present in `next` into the default branch, another step towards releasing `pa11y@7`.

## Additional changes alongside those in `next`

1. Supports `push` to `main` in preparation for next build on `main` when merged, part of:
    https://github.com/pa11y/org/issues/19
1. Some renaming, and also removal of naming and comments where content was descriptive

### Repo settings updates

1. Require new jobs in matrix to pass
1. Rename default branch to `main` from `master`
 
## Changes arriving from `next`

By @aarongoldenthal and @josebolos in:
- #647 

### New arrivals
1. Add Windows and macOS to GA matrix
1. Set test-specific environment variables within Jest setup
1. Move env var to global since needed there and run before setup
1. Update path resolution to be platform independent, and fix issues
1. Update cli runner to call node since Windows ignores the shebang in bin
1. Increase timeout for Mac tests timing out

### Already present in default branch
1. ~~Update Node.js support to 18, 20~~