### PR TITLE
Clean up nomenclature to properly reference runner, not reporter

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -378,15 +378,15 @@ function loadRunnerFile(runner) {
  * @param {String} runnerName - The name of the runner.
  * @param {String} runnerSupportString - The runner support string (a semver range).
  * @param {String} pa11yVersion - The version of Pa11y to test support for.
- * @throws {Error} Throws an error if the reporter does not support the given version of Pa11y
+ * @throws {Error} Throws an error if the runner does not support the given version of Pa11y
  * @returns {void}
  */
-function assertReporterCompatibility(runnerName, runnerSupportString, pa11yVersion) {
+function assertRunnerCompatibility(runnerName, runnerSupportString, pa11yVersion) {
 	if (!runnerSupportString || !semver.satisfies(pa11yVersion, runnerSupportString)) {
 		throw new Error([
 			`The installed "${runnerName}" runner does not support Pa11y ${pa11yVersion}`,
 			'Please update your version of Pa11y or the runner',
-			`Reporter Support: ${runnerSupportString}`,
+			`Runner Support: ${runnerSupportString}`,
 			`Pa11y Version:    ${pa11yVersion}`
 		].join('\n'));
 	}
@@ -395,14 +395,14 @@ function assertReporterCompatibility(runnerName, runnerSupportString, pa11yVersi
 /**
  * Loads a runner script
  * @param {String} runner - The name of the runner.
- * @throws {Error} Throws an error if the reporter does not support the given version of Pa11y
+ * @throws {Error} Throws an error if the runner does not support the given version of Pa11y
  * @returns {String} Javascript source of the runner
  */
 function loadRunnerScript(runner) {
 	const runnerModule = loadRunnerFile(runner);
 	let runnerBundle = '';
 
-	assertReporterCompatibility(runner, runnerModule.supports, pkg.version);
+	assertRunnerCompatibility(runner, runnerModule.supports, pkg.version);
 
 	for (const runnerScript of runnerModule.scripts) {
 		runnerBundle += '\n\n';

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -848,7 +848,7 @@ describe('lib/pa11y', () => {
 				expect(rejectedError.message).toEqual([
 					`The installed "node-module" runner does not support Pa11y ${pkg.version}`,
 					'Please update your version of Pa11y or the runner',
-					'Reporter Support: mock-support-string',
+					'Runner Support: mock-support-string',
 					`Pa11y Version:    ${pkg.version}`
 				].join('\n'));
 			});


### PR DESCRIPTION
It appears some of the reporter loading/validation logic was copied to support runners, but some "reporter" references were overlooked. This cleans up the runner loading/validation logic and tests to properly reference `runner` instead of `reporter`.