### PR TITLE
Fix flake affecting `wait-for-element-event` integration tests

### DIFF
--- a/test/integration/cli/exit-codes.test.js
+++ b/test/integration/cli/exit-codes.test.js
@@ -29,10 +29,9 @@ describe('CLI exit codes', () => {
 
 	});
 
-	// This has to be skipped for now, some ISPs hijack hostnames that can't
-	// be resolved (looking at you TalkTalk). We could do with finding a better
-	// way to test this later
-	describe.skip(`when Pa11y is run on a page that can't be loaded`, () => {
+	// An ISP may redirect an unresolvable hostname to a working page,
+	// which could cause this test to fail when run locally.
+	describe(`when Pa11y is run on a page that can't be loaded`, () => {
 
 		beforeAll(async () => {
 			pa11yResponse = await runPa11yCli('notahost');

--- a/test/integration/cli/wait.test.js
+++ b/test/integration/cli/wait.test.js
@@ -13,7 +13,7 @@ describe('CLI wait', () => {
 		beforeAll(async () => {
 			pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/wait`, {
 				arguments: [
-					'--wait', '2100',
+					'--wait', '2500',
 					'--reporter', 'json'
 				]
 			});

--- a/test/integration/mock/html/actions-wait-for-element-event.html
+++ b/test/integration/mock/html/actions-wait-for-element-event.html
@@ -20,13 +20,14 @@ after an event has been emitted.
 	<div id="event-target">will emit an event</div>
 
 	<script>
+		const timeoutSufficientToAvoidTestFlake = 5000;
 		const eventTarget = document.querySelector('#event-target');
 		eventTarget.addEventListener('example-event', () => {
 			document.querySelector('img').remove();
 		});
 		setTimeout(() => {
 			eventTarget.dispatchEvent(new Event('example-event'));
-		}, 100);
+		}, timeoutSufficientToAvoidTestFlake);
 	</script>
 
 </body>

--- a/test/integration/mock/html/actions-wait-for-element-event.html
+++ b/test/integration/mock/html/actions-wait-for-element-event.html
@@ -26,7 +26,7 @@ after an event has been emitted.
 		});
 		setTimeout(() => {
 			eventTarget.dispatchEvent(new Event('example-event'));
-		}, 2000);
+		}, 100);
 	</script>
 
 </body>


### PR DESCRIPTION
This PR:

1. resolves (hopefully resolves) the test flake that has frequently been causing this test to fail on `macos-latest` in GitHub Actions.  Hypothesis: Puppeteer was dispatching the event before having its listener in place.
1. increases the `--wait` test's legroom from 100ms to 500ms since that has failed occasionally too 
1. reinstates the `notahost` test, since it works in GitHub Actions

Thanks for the nudge @aarongoldenthal 