### PR TITLE
[WIP] Fix axe level translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.2.3",
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "axe-core": "~4.8.2",
+        "axe-core": "^4.8.2",
         "bfj": "~8.0.0",
         "commander": "~11.1.0",
         "envinfo": "~7.11.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "npm": ">=10"
   },
   "dependencies": {
-    "axe-core": "~4.8.2",
+    "axe-core": "^4.8.2",
     "bfj": "~8.0.0",
     "commander": "~11.1.0",
     "envinfo": "~7.11.0",


### PR DESCRIPTION
Full description pending.

- intended to fix #623 

#### Thoughts

- [ ] **Semver:** I've pencilled this in for `7.0.1`, but would this fix be considered to require a major bump?  So far I've seen a couple of workarounds that ignore rules that are emitting these false positives but I suppose people could be forming a contract with Pa11y's current output.  On the other hand, it isn't behaviour we intended - it's a bug.