### PR TITLE
Use native `AbortSignal` in place of `p-timeout`

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -5,7 +5,6 @@ const option = require('./option');
 const fs = require('fs');
 const path = require('path');
 const pkg = require('../package.json');
-const promiseTimeout = require('p-timeout');
 const puppeteer = require('puppeteer');
 const semver = require('semver');
 
@@ -33,13 +32,10 @@ async function pa11y(url, options = {}, callback) {
 
 		// Call the actual Pa11y test runner with
 		// a timeout if it takes too long
-		pa11yResults = await promiseTimeout(
-			runPa11yTest(url, options, state),
-			options.timeout,
-			`Pa11y timed out (${options.timeout}ms)`
-		);
+		pa11yResults = await runPa11yTest(url, options, state, {
+			signal: AbortSignal.timeout(options.timeout)
+		});
 	} catch (error) {
-		// Capture error if a callback is provided, otherwise reject with error
 		if (callback) {
 			pa11yError = error;
 		} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "kleur": "~4.1.5",
         "mustache": "~4.2.0",
         "node.extend": "~2.0.3",
-        "p-timeout": "~4.1.0",
         "puppeteer": "^22.3.0",
         "semver": "~7.6.0"
       },
@@ -4344,14 +4343,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/p-try": {
@@ -8816,11 +8807,6 @@
       "requires": {
         "p-limit": "^3.0.2"
       }
-    },
-    "p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
     },
     "p-try": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "kleur": "~4.1.5",
     "mustache": "~4.2.0",
     "node.extend": "~2.0.3",
-    "p-timeout": "~4.1.0",
     "puppeteer": "^22.3.0",
     "semver": "~7.6.0"
   },

--- a/test/integration/cli/timeout.test.js
+++ b/test/integration/cli/timeout.test.js
@@ -21,8 +21,8 @@ describe('CLI timeout', () => {
 
 		it('outputs a timeout error', () => {
 			expect(pa11yResponse.output).toMatch(/timeouterror/i);
-			expect(pa11yResponse.output).toMatch(/pa11y timed out/i);
-			expect(pa11yResponse.output).toMatch(/100ms/i);
+			expect(pa11yResponse.output).toMatch(/navigation timeout/i);
+			expect(pa11yResponse.output).toMatch(/100 ms/i);
 		});
 
 	});

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -21,7 +21,6 @@ describe('lib/pa11y', () => {
 	let puppeteer;
 	let extend;
 	let semver;
-	let promiseTimeout;
 
 	beforeEach(() => {
 		pa11yResults = {
@@ -56,15 +55,10 @@ describe('lib/pa11y', () => {
 				return jest.fn(actual);
 			});
 			jest.doMock('semver', () => require('../mocks/semver.mock'));
-			jest.doMock('p-timeout', () => {
-				const actual = jest.requireActual('p-timeout');
-				return jest.fn(actual);
-			});
 
 			extend = require('node.extend');
 			puppeteer = require('puppeteer');
 			semver = require('semver');
-			promiseTimeout = require('p-timeout');
 
 			puppeteer.mockPage.evaluate.mockResolvedValue(pa11yResults);
 
@@ -96,13 +90,6 @@ describe('lib/pa11y', () => {
 			expect(typeof extend.mock.calls[0][0]).toBe('object');
 			expect(extend.mock.calls[0][1]).toEqual(pa11y.defaults);
 			expect(extend.mock.calls[0][2]).toEqual({});
-		});
-
-		it('uses a promise timeout function', () => {
-			expect(promiseTimeout).toHaveBeenCalledTimes(1);
-			expect(promiseTimeout.mock.calls[0][0]).toEqual(expect.any(Promise));
-			expect(promiseTimeout.mock.calls[0][1]).toEqual(pa11y.defaults.timeout);
-			expect(promiseTimeout.mock.calls[0][2]).toEqual(`Pa11y timed out (${pa11y.defaults.timeout}ms)`);
 		});
 
 		it('launches puppeteer with `options.chromeLaunchConfig`', () => {


### PR DESCRIPTION
## Summary

Replace the use of [p-timeout](https://github.com/sindresorhus/p-timeout) with Node's native [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static) (Node 15+), given we can no longer update `p-timeout` beyond version 4 due to [the author's stance](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) on ESM and CommonJS.  Parity is maintained with the previous implementation.

## Detail

1. Remove dependency `p-timeout`.
2. In this PR's revision the recipient of the `AbortSignal` does not interact with or listen to it, but this implementation still achieves parity with the previous version.
3. Remove the unit test of the calls to the dependency, without replacing it.  This test was closely tied to the implementation and the behaviour is covered by the corresponding integration test.

## To review timeout presentation locally

```shell
nvm install 20
npx \
    pa11y/pa11y#update-ptimeout-to-abortsignal \
    https://example.com \
    --timeout 1
```

Expected:

```console
Welcome to Pa11y

 > Running Pa11y on URL https://example.com

Error: TimeoutError: Navigation timeout of 1 ms exceeded
    (etc)
```