### PR TITLE
[WIP, test with v21 until 23/04/24] Verify Node 22 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20]
+        node-version: [18, 20, 21]
     steps:
       - name: Normalise line-ending handling in Git
         shell: bash


### PR DESCRIPTION
Node 22 will:

- be available from 23/04/24
- enter LTS in October

[Release schedule](https://github.com/nodejs/Release#release-schedule)