### PR TITLE
Clean up several minor issues in setPage

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -245,7 +245,7 @@ async function interceptRequests(options, state) {
 async function gotoUrl(url, options, state) {
 	// Navigate to the URL we're going to test
 	if (!options.ignoreUrl) {
-		options.log.debug(`Opening URL ${url}`);
+		options.log.debug(`Navigating to ${url}`);
 		await state.page.goto(url, {
 			waitUntil: 'networkidle2',
 			timeout: options.timeout

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -162,7 +162,6 @@ async function setPage(options, state) {
 	};
 
 	state.page.on('console', state.consoleCallback);
-	options.log.debug('Opening URL in Headless Chrome');
 	if (options.userAgent) {
 		await state.page.setUserAgent(options.userAgent);
 	}
@@ -242,6 +241,7 @@ async function interceptRequests(options, state) {
 async function gotoUrl(url, options, state) {
 	// Navigate to the URL we're going to test
 	if (!options.ignoreUrl) {
+		options.log.debug(`Opening URL ${url}`);
 		await state.page.goto(url, {
 			waitUntil: 'networkidle2',
 			timeout: options.timeout

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -63,7 +63,7 @@ async function runPa11yTest(url, options, state) {
 
 	await setBrowser(options, state);
 
-	await setPage(url, options, state);
+	await setPage(options, state);
 
 	await interceptRequests(options, state);
 
@@ -139,13 +139,12 @@ async function setBrowser(options, state) {
 /**
  * Configures the browser page to be used for the test.
  * @private
- * @param {Object} url - The URL to test against
  * @param {Object} [options] - Options to change the way tests run.
  * @param {Object} state - The current pa11y internal state, fields will be mutated by
  *   this function.
  * @returns {Promise} A promise which resolves when the page has been configured.
  */
-async function setPage(url, options, state) {
+async function setPage(options, state) {
 	if (options.browser && options.page) {
 		state.page = options.page;
 		state.autoClosePage = false;

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -146,9 +146,11 @@ async function setBrowser(options, state) {
  */
 async function setPage(options, state) {
 	if (options.browser && options.page) {
+		options.log.debug('Using provided browser page');
 		state.page = options.page;
 		state.autoClosePage = false;
 	} else {
+		options.log.debug('Opening new browser page');
 		state.page = await state.browser.newPage();
 		state.autoClosePage = true;
 	}
@@ -163,8 +165,10 @@ async function setPage(options, state) {
 
 	state.page.on('console', state.consoleCallback);
 	if (options.userAgent) {
+		options.log.debug(`Setting page User-Agent to "${options.userAgent}"`);
 		await state.page.setUserAgent(options.userAgent);
 	}
+	options.log.debug('Setting page viewport');
 	await state.page.setViewport(options.viewport);
 }
 


### PR DESCRIPTION
The following issues were noticed today in the `setPage` function (all are low priority cleanup).

- Removed unused `url` argument from `setPage`
- Moved debug log entry for navigating to URL to proper location (from `setPage` to `gotoUrl`)
- Update debug logging for all `setPage` operations

Debug log changes:

```diff
 > pa11y -d https://pa11y.org

 Welcome to Pa11y

  > Running Pa11y on URL https://pa11y.org
  > Debug: Launching Headless Chrome
- > Debug: Opening URL in Headless Chrome
+ > Debug: Opening new browser page
+ > Debug: Setting page User-Agent to "pa11y/8.0.0"
+ > Debug: Setting page viewport
+ > Debug: Navigating to https://pa11y.org
  > Debug: Loading runner: htmlcs
  > Debug: Injecting Pa11y
  > Debug: Injecting runner: htmlcs
  > Debug: Running Pa11y on the page
  > Debug: Document title: "Pa11y"

 No issues found!
```
