### PR TITLE
Release `pa11y@9.0.0`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - name: Normalise line-ending handling in Git
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Normalise line-ending handling in Git
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 8.1.0 (2025-05-04)
+
+Pa11y 8.1 updates to the latest version of Puppeteer (`24`) and Axe (`4.10`), updates several other dependencies, and includes some GitHub actions and documentation cleanup.
+
+### Changes in `pa11y@8.1`
+
+* **Significant dependency changes (potentially impacting Pa11y results)**:
+  * Upgrade `puppeteer` to `24` from `22`. This updates the underlying Chrome version (to `135`).
+  * Upgrade `axe-core` to `4.10` from `4.8`. This includes rule fixes that may change results when using the `axe` runner. See `axe-core` [releases](https://github.com/dequelabs/axe-core/releases) for complete details.
+* Other dependency changes:
+  * Upgrade `bfj` to `9.1` from `8.0`.
+  * Upgrade `commander` to `13.1` from `12.0`.
+  * Upgrade `envinfo` to `7.14` from `7.11`.
+  * Upgrade `semver` to `7.7` from `7.6`.
+* GitHub Actions changes: Update workflows for Node 22, Ubuntu 24.04 compatibility, and [publishing package with provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/).
+* Other changes: Refactor code and tests for dependency compatibility, update support table and fix some links in the README.
+
+### New contributors in `pa11y@8.1`
+
+* @kaitlinnewson [made their first contribution](https://github.com/pa11y/pa11y/pull/712)
+
+### Full diff for `pa11y@8.1`
+
+* [8.0.0...8.1.0](https://github.com/pa11y/pa11y/compare/8.0.0...8.1.0)
+
 ## 8.0.0 (2024-03-25)
 
 Pa11y 8 makes the latest version of Puppeteer (`22`) available to Pa11y and updates several other dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 8.1.0 (2025-05-04)
+## 9.0.0 (2025-05-07)
 
-Pa11y 8.1 updates to the latest version of Puppeteer (`24`) and Axe (`4.10`), updates several other dependencies, and includes some GitHub actions and documentation cleanup.
+Pa11y 9 requires a stable (even-numbered) Node.js version of `20` or above, updates to the latest version of Puppeteer (`24`) and Axe (`4.10`), updates several other dependencies, and includes some GitHub actions and documentation cleanup.
 
-### Changes in `pa11y@8.1`
+### Changes in `pa11y@9`
 
+* **Breaking**: Upgrade Node.js support: Pa11y 9 requires a stable (even-numbered) Node.js version of `20` or above
 * **Significant dependency changes (potentially impacting Pa11y results)**:
   * Upgrade `puppeteer` to `24` from `22`. This updates the underlying Chrome version (to `135`).
   * Upgrade `axe-core` to `4.10` from `4.8`. This includes rule fixes that may change results when using the `axe` runner. See `axe-core` [releases](https://github.com/dequelabs/axe-core/releases) for complete details.
@@ -14,16 +15,16 @@ Pa11y 8.1 updates to the latest version of Puppeteer (`24`) and Axe (`4.10`), up
   * Upgrade `commander` to `13.1` from `12.0`.
   * Upgrade `envinfo` to `7.14` from `7.11`.
   * Upgrade `semver` to `7.7` from `7.6`.
-* GitHub Actions changes: Update workflows for Node 22, Ubuntu 24.04 compatibility, and [publishing package with provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/).
+* GitHub Actions changes: Update workflows for Node 22/24, Ubuntu 24.04 compatibility, and [publishing package with provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/).
 * Other changes: Refactor code and tests for dependency compatibility, update support table and fix some links in the README.
 
-### New contributors in `pa11y@8.1`
+### New contributors in `pa11y@9`
 
 * @kaitlinnewson [made their first contribution](https://github.com/pa11y/pa11y/pull/712)
 
-### Full diff for `pa11y@8.1`
+### Full diff for `pa11y@9`
 
-* [8.0.0...8.1.0](https://github.com/pa11y/pa11y/compare/8.0.0...8.1.0)
+* [8.0.0...9.0.0](https://github.com/pa11y/pa11y/compare/8.0.0...9.0.0)
 
 ## 8.0.0 (2024-03-25)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Pa11y's API changes between major versions. This is a guide to help you make the
 
 ## Table of contents
 
+* [Migrating from 8.0 to 9.0](#migrating-from-80-to-90)
 * [Migrating from 7.0 to 8.0](#migrating-from-70-to-80)
 * [Migrating from 6.0 to 7.0](#migrating-from-60-to-70)
 * [Migrating from 5.0 to 6.0](#migrating-from-50-to-60)
@@ -11,6 +12,12 @@ Pa11y's API changes between major versions. This is a guide to help you make the
 * [Migrating from 3.0 to 4.0](#migrating-from-30-to-40)
 * [Migrating from 2.0 to 3.0](#migrating-from-20-to-30)
 * [Migrating from 1.0 to 2.0](#migrating-from-10-to-20)
+
+## Migrating from 8.0 to 9.0
+
+Pa11y 9 requires a stable (even-numbered) Node.js version of `20` or above.
+
+We've also upgraded to Puppeteer `24` (from `20`), Axe `4.10` (from `4.8`), and to more recent major versions of several other dependencies - see [Pa11y's changelog](CHANGELOG.md) for the list. Those changes should not affect most users of Pa11y.
 
 ## Migrating from 7.0 to 8.0
 

--- a/README.md
+++ b/README.md
@@ -943,7 +943,8 @@ The following table lists the major versions available and, for each previous ma
 
 | Major version | Final minor version | Node.js support  | Puppeteer version | Support end date         |
 | :------------ | :------------------ | :--------------- | :---------------- | :----------------------- |
-| `8`           |                     | `18`, `20`, `22` | `^24`             | ✅ Current major version |
+| `9`           |                     | `20`, `22`, `24` | `^24`             | ✅ Current major version |
+| `8`           | `8.0`               | `18`, `20`, `22` | `^22`             | 2025-11-07               |
 | `7`           | `7.0`               | `18`, `20`       | `^20`             | 2024-10-02               |
 | `6`           | `6.2`               | `12`, `14`, `16` | `~9.1`            | 2024-07-16               |
 | `5`           | `5.3`               | `8`, `10`, `12`  | `^1`              | 2021-11-25               |

--- a/lib/reporters/cli.js
+++ b/lib/reporters/cli.js
@@ -5,7 +5,7 @@ const {cyan, green, grey, red, underline, yellow} = require('kleur');
 const report = module.exports = {};
 
 // Pa11y version support
-report.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+report.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 // Helper strings for use in reporter methods
 const start = cyan(' >');

--- a/lib/reporters/csv.js
+++ b/lib/reporters/csv.js
@@ -3,7 +3,7 @@
 const report = module.exports = {};
 
 // Pa11y version support
-report.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+report.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 // Output formatted results
 report.results = results => {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -9,7 +9,7 @@ const readFile = promisify(fs.readFile);
 const report = module.exports = {};
 
 // Pa11y version support
-report.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+report.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 // Compile template and output formatted results
 report.results = async results => {

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -5,7 +5,7 @@ const bfj = require('bfj');
 const report = module.exports = {};
 
 // Pa11y version support
-report.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+report.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 // Output formatted results
 // NOTE: unlike other reporters, the JSON reporter uses streams and so outputs

--- a/lib/reporters/tsv.js
+++ b/lib/reporters/tsv.js
@@ -3,7 +3,7 @@
 const report = module.exports = {};
 
 // Pa11y version support
-report.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+report.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 // Output formatted results
 report.results = results => {

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -10,7 +10,7 @@ const runner = module.exports = {};
  * @public
  * @type {Array}
  */
-runner.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+runner.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 /**
  * Scripts which the test runner depends on.

--- a/lib/runners/htmlcs.js
+++ b/lib/runners/htmlcs.js
@@ -7,7 +7,7 @@ const runner = module.exports = {};
  * @public
  * @type {Array}
  */
-runner.supports = '^8.0.0 || ^8.0.0-alpha || ^8.0.0-beta';
+runner.supports = '^9.0.0 || ^9.0.0-alpha || ^9.0.0-beta';
 
 /**
  * Scripts which the test runner depends on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "axe-core": "~4.10.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y",
-      "version": "8.1.0",
+      "version": "9.0.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "axe-core": "~4.10.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "sinon": "^20.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "bugs": "https://github.com/pa11y/pa11y/issues",
   "license": "LGPL-3.0-only",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "axe-core": "~4.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "accessibility",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "accessibility",


### PR DESCRIPTION
Changes in this PR:

* [x] Removed Node 18 tests, EOL as of 2025-04-30.
* [x] Added Node 24 tests, released 2025-05-06.
* [x] Update `package.json` to support Node >= 20 based on latest Node LTS releases.
* [x] Updated `CHANGELOG.md`
* [x] Update `MIGRATION.md` since a major release
* [x] Updated `package.json`/`package-lock.json` to version 9.0.0
* [x] Updated all `reporters` and `runners` for v9 support
* [x] Created [draft release for v9.0.0](https://github.com/pa11y/pa11y/releases).

