### PR TITLE
Limit GitHub Actions Workflow permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR limits the permissions of the GITHUB_TOKEN for the test/lint Action Workflow to read only. The default permissions for repositories created before February 2023, like this one, is read-write. This resolves two issues identified by CodeQL (https://github.com/pa11y/pa11y/security/code-scanning/5 and https://github.com/pa11y/pa11y/security/code-scanning/6, for those with the appropriate permissions).

Co-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>