### PR TITLE
Upgrade commander to match version in pa11y-ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "pa11y",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "axe-core": "~4.10.3",
         "bfj": "~9.1.2",
-        "commander": "~13.1.0",
+        "commander": "~14.0.1",
         "envinfo": "~7.14.0",
         "html_codesniffer": "~2.5.1",
         "kleur": "~4.1.5",
@@ -928,12 +928,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "axe-core": "~4.10.3",
     "bfj": "~9.1.2",
-    "commander": "~13.1.0",
+    "commander": "~14.0.1",
     "envinfo": "~7.14.0",
     "html_codesniffer": "~2.5.1",
     "kleur": "~4.1.5",


### PR DESCRIPTION
This allows NPM to dedup the dependencies when installing, which reduces the installation size.

At the moment, a pa11y-ci user will have both v13 and v14 of commander installed.