### PR TITLE
Restrict publishing to the main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 on:
   release:
     types: [created, edited, published]
+    branches: [main]
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
This will hopefully help prevent mistakes when publishing