### PR TITLE
Clarify README configuration details and add config file examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ pa11y.isValidAction('open the pod bay doors'); // false
 
 ## Configuration
 
-Pa11y has lots of options you can use to change the way Headless Chrome runs, or the way your page is loaded. Options can be set either as a parameter on the `pa11y` function or in a [JSON configuration file](#command-line-configuration). Some are also available directly as [command-line options](#command-line-interface).
+Pa11y has lots of options you can use to change the way Headless Chrome runs, or the way your page is loaded. Options can be set either as a parameter on the `pa11y` function or in a [JSON or JavaScript configuration file](#command-line-configuration). Some are also available directly as [command-line options](#command-line-interface).
 
-Below is a reference of all the options that are available:
+Below is a reference of all the options that are available. Example [JSON](example/configs/pa11y.json) and [JavaScript](example/configs/pa11y.js) configuration files are available in `example/configs/`. Note that unlike [`pa11y-ci` configuration](https://github.com/pa11y/pa11y-ci?tab=readme-ov-file#default-configuration), there is no `defaults` property.
 
 ### `actions` (array)
 

--- a/example/configs/pa11y.js
+++ b/example/configs/pa11y.js
@@ -1,0 +1,7 @@
+// Example pa11y config with values set via environment variables
+module.exports = {
+	headers: {
+		Cookie: "foo=bar",
+	},
+	includeWarnings: process.env.INCLUDE_WARNINGS === "true",
+};

--- a/example/configs/pa11y.json
+++ b/example/configs/pa11y.json
@@ -1,0 +1,6 @@
+{
+	"headers": {
+		"Cookie": "foo=bar"
+	},
+	"includeWarnings": true
+}


### PR DESCRIPTION
Per #776, as well as previous examples, there is some community confusion between the pa11y and pa11y-ci config file formats and where `defaults` should be included. This PR adds some clarifying words to the configuration section of the README, and dedicated JSON and JavaScript examples.

Closes #776