### PR TITLE
Fix custom runner issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,18 +169,18 @@ The command-line tool can provide test results in a few different ways using the
 - `json`: output test results as a JSON array
 - `tsv`: output test results as tab-separated values
 
-You can also write and publish your own reporters. Pa11y looks for reporters in your `node_modules` folder (with a naming pattern), and the current working directory. The first reporter found will be loaded. So with this command:
+You can also write and publish your own reporters, which must be [CommonJS modules](https://nodejs.org/api/modules.html#modules-commonjs-modules), and may be installed packages or local files. Pa11y checks for reporter modules in a specific order, and the first reporter found will be loaded. So with this command:
 
 ```sh
 pa11y https://example.com --reporter rainbows 
 ```
 
-The following locations will be checked:
+The following locations will be checked, in order:
 
-```sh
-<cwd>/node_modules/pa11y-reporter-rainbows
-<cwd>/rainbows
-```
+- An installed package named `pa11y-reporter-rainbows`
+- A module file located at `<cwd>/rainbows`
+
+For each of these, Pa11y will use the standard Node.js `require` function to attempt to load the module, so the module must be resolvable by `require`, and follows the standard [CommonJS module resolution order](https://nodejs.org/api/modules.html#modules-commonjs-modules). If no runner is found then Pa11y will error.
 
 A Pa11y reporter _must_ export a string property named `supports`. This is a [semver range] which indicates which versions of Pa11y the reporter supports:
 
@@ -849,19 +849,19 @@ Pa11y supports multiple test runners which return different results. The built-i
 - `axe`: run tests using [axe-core][axe].
 - `htmlcs` (default): run tests using [HTML_CodeSniffer][htmlcs]
 
-You can also write and publish your own runners. Pa11y looks for runners in your `node_modules` folder (with a naming pattern), and the current working directory. The first runner found will be loaded. So with this command:
+You can also write and publish your own runners, which must be [CommonJS modules](https://nodejs.org/api/modules.html#modules-commonjs-modules), and may be installed packages or local files. Pa11y checks for runner modules in a specific order, and the first runner found will be loaded. So with this command:
 
 ```sh
 pa11y https://example.com --runner custom-tool
 ```
 
-The following locations will be checked:
+The following locations will be checked, in order:
 
-```sh
-<cwd>/node_modules/pa11y-runner-custom-tool
-<cwd>/node_modules/custom-tool
-<cwd>/custom-tool
-```
+- An installed package named `pa11y-runner-custom-tool`
+- An installed package named `custom-tool` or a module file located at absolute path `custom-tool` (in this case it would most likely be something like `/path/to/custom-tool`)
+- A module file located at `<cwd>/custom-tool`
+
+For each of these, Pa11y will use the standard Node.js `require` function to attempt to load the module, so the module must be resolvable by `require`, and follows the standard [CommonJS module resolution order](https://nodejs.org/api/modules.html#modules-commonjs-modules). If no runner is found then Pa11y will error.
 
 A Pa11y runner _must_ export a string property named `supports`. This is a [semver range] which indicates which versions of Pa11y the runner supports:
 

--- a/bin/pa11y.js
+++ b/bin/pa11y.js
@@ -8,6 +8,7 @@ const path = require('path');
 const pkg = require('../package.json');
 const {program} = require('commander');
 const pa11y = require('../lib/pa11y');
+const {requireFirst} = require('../lib/helpers');
 const semver = require('semver');
 
 const programOptions = program.opts();
@@ -250,26 +251,6 @@ function checkReporterCompatibility(reporterName, reporterSupportString, pa11yVe
 		console.error(`Reporter Support: ${reporterSupportString}`);
 		console.error(`Pa11y Version:    ${pa11yVersion}`);
 		process.exit(1);
-	}
-}
-
-/**
- * Traverses a number of directories trying to load a config file from them
- * @param {String[]} stack - A list of directories
- * @param {Object} defaultReturn - The object to return if no config is found
- * @returns {Object} A config object
- */
-function requireFirst(stack, defaultReturn) {
-	if (!stack.length) {
-		return defaultReturn;
-	}
-	try {
-		return require(stack.shift());
-	} catch (error) {
-		if (error.code === 'MODULE_NOT_FOUND') {
-			return requireFirst(stack, defaultReturn);
-		}
-		throw error;
 	}
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Traverses a number of directories trying to load a config file from them
+ * @param {String[]} stack - A list of directories
+ * @param {Object} defaultReturn - The object to return if no config is found
+ * @returns {Object} A config object
+ */
+function requireFirst(stack, defaultReturn) {
+	if (!stack.length) {
+		return defaultReturn;
+	}
+	try {
+		return require(stack.shift());
+	} catch (error) {
+		if (error.code === 'MODULE_NOT_FOUND') {
+			return requireFirst(stack, defaultReturn);
+		}
+		throw error;
+	}
+}
+
+module.exports = {
+	requireFirst
+};

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -402,6 +402,7 @@ function loadRunnerFile(runner) {
 		);
 		console.error('with Pa11y itself, please check your runner configuration or contact the');
 		console.error('creator of this runner\n');
+		console.error(error.stack);
 		throw error;
 	}
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const {version: pa11yVersion} = require('../package.json');
 const puppeteer = require('puppeteer');
+const {requireFirst} = require('../lib/helpers');
 const semver = require('semver');
 
 const runnersJavascript = {};
@@ -379,15 +380,35 @@ async function saveScreenCapture(options, state) {
  * @return {Object} Returns the required module.
  */
 function loadRunnerFile(runner) {
-	switch (runner) {
-		// Load internal runners directly
-		case 'axe':
-			return require(path.join(__dirname, 'runners', 'axe'));
-		case 'htmlcs':
-			return require(path.join(__dirname, 'runners', 'htmlcs'));
-		default:
-			return require(runner);
+	let runnerModule;
+
+	try {
+		// Load built-in runners by name from the runners directory.
+		if (['axe', 'htmlcs'].includes(runner)) {
+			runnerModule = require(path.join(__dirname, 'runners', runner));
+		} else {
+			runnerModule = requireFirst([
+				// Standard runner module name
+				`pa11y-runner-${runner}`,
+				// Absolute path of runner or runner module full name
+				runner,
+				// Relative path of runner
+				path.join(process.cwd(), runner)
+			], null);
+		}
+	} catch (error) {
+		console.error(
+			`An error occurred when loading the "${runner}" runner. This is not an error`
+		);
+		console.error('with Pa11y itself, please check your runner configuration or contact the');
+		console.error('creator of this runner\n');
+		throw error;
 	}
+
+	if (!runnerModule) {
+		throw new Error(`Runner "${runner}" could not be found`);
+	}
+	return runnerModule;
 }
 
 /**

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -430,9 +430,10 @@ function loadRunnerScript(name) {
 		script => fs.readFileSync(script, 'utf-8')
 	).join('\n\n');
 
+	// JSON.stringify escapes all characters required to produce a valid quoted string.
 	return `
 		;${runnerBundle};
-		;window.__pa11y.runners['${name}'] = ${run.toString()};
+		;window.__pa11y.runners[${JSON.stringify(name)}] = ${run.toString()};
 	`;
 }
 

--- a/test/integration/cli/runner-custom.test.js
+++ b/test/integration/cli/runner-custom.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('proclaim');
+const path = require('node:path');
+const runPa11yCli = require('../helper/pa11y-cli');
+
+const testRunner = async function(runnerPath) {
+	const pa11yResponse = await runPa11yCli(`${global.mockWebsiteAddress}/errors`, {
+		arguments: [
+			'--runner', runnerPath,
+			'--reporter', 'json',
+			'--include-notices',
+			'--include-warnings'
+		]
+	});
+
+	assert.isArray(pa11yResponse.json);
+	assert.lengthEquals(pa11yResponse.json, 3);
+	assert.equal(pa11yResponse.json[0].type, 'error');
+	assert.equal(pa11yResponse.json[1].type, 'warning');
+	assert.equal(pa11yResponse.json[2].type, 'warning');
+};
+
+describe('CLI custom runner', function() {
+	describe('using relative (Linux/Windows) file path', function() {
+		it('outputs the expected issues', async function() {
+			// RunPa11yCli sets cwd to `__dirname/..`, which is `test/integration`,
+			// so the path must be relative to that.
+			const runnerPath = path.join('..', '..', 'lib', 'runners', 'axe.js');
+			await testRunner(runnerPath);
+		});
+	});
+
+	describe('using absolute (Linux/Windows) file path', function() {
+		it('outputs the expected issues', async function() {
+			const runnerPath = path.join(process.cwd(), 'lib', 'runners', 'axe.js');
+			await testRunner(runnerPath);
+		});
+	});
+});

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -129,7 +129,7 @@ describe('lib/pa11y', function() {
 		it('evaluates the HTML CodeSniffer vendor and runner JavaScript', function() {
 			assert.called(puppeteer.mockPage.evaluate);
 			assert.match(puppeteer.mockPage.evaluate.secondCall.args[0], /^\s*;\s*mock-html-codesniffer-js\s*;/);
-			assert.match(puppeteer.mockPage.evaluate.secondCall.args[0], /;\s*window\.__pa11y\.runners\['htmlcs'\] = async options\s*=>.*/);
+			assert.match(puppeteer.mockPage.evaluate.secondCall.args[0], /;\s*window\.__pa11y\.runners\["htmlcs"\] = async options\s*=>.*/);
 		});
 
 		it('evaluates the the Pa11y runner JavaScript', function() {
@@ -815,8 +815,8 @@ describe('lib/pa11y', function() {
 			it('evaluates all vendor script and runner JavaScript', function() {
 				assert.called(puppeteer.mockPage.evaluate);
 
-				assert.match(puppeteer.mockPage.evaluate.getCall(1).args[0], /^\s*;\s*mock-runner-node-module-1-js\s*;\s*;\s*window\.__pa11y\.runners\['node-module-1'\] = \(\)\s*=>\s*'mock-runner-node-module-1'\s*;\s*$/);
-				assert.match(puppeteer.mockPage.evaluate.getCall(2).args[0], /^\s*;\s*mock-runner-node-module-2-js\s*;\s*;\s*window\.__pa11y\.runners\['node-module-2'\] = \(\)\s*=>\s*'mock-runner-node-module-2'\s*;\s*$/);
+				assert.match(puppeteer.mockPage.evaluate.getCall(1).args[0], /^\s*;\s*mock-runner-node-module-1-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-1"\] = \(\)\s*=>\s*'mock-runner-node-module-1'\s*;\s*$/);
+				assert.match(puppeteer.mockPage.evaluate.getCall(2).args[0], /^\s*;\s*mock-runner-node-module-2-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-2"\] = \(\)\s*=>\s*'mock-runner-node-module-2'\s*;\s*$/);
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -783,7 +783,7 @@ describe('lib/pa11y', function() {
 						'/mock-runner-node-module-1/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-runner-node-module-1'
+					run: /* istanbul ignore next */ () => 'mock-runner-node-module-1-run'
 				};
 				quibble('node-module-1', mockRunnerNodeModule1);
 
@@ -793,7 +793,7 @@ describe('lib/pa11y', function() {
 						'/mock-runner-node-module-2/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-runner-node-module-2'
+					run: /* istanbul ignore next */ () => 'mock-runner-node-module-2-run'
 				};
 				quibble('node-module-2', mockRunnerNodeModule2);
 
@@ -815,14 +815,15 @@ describe('lib/pa11y', function() {
 			it('evaluates all vendor script and runner JavaScript', function() {
 				assert.called(puppeteer.mockPage.evaluate);
 
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(1).args[0],
-					/^\s*;\s*mock-runner-node-module-1-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-1"\] = \(\)\s*=>\s*'mock-runner-node-module-1'\s*;\s*$/
-				);
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(2).args[0],
-					/^\s*;\s*mock-runner-node-module-2-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-2"\] = \(\)\s*=>\s*'mock-runner-node-module-2'\s*;\s*$/
-				);
+				const evaluateCall1 = puppeteer.mockPage.evaluate.getCall(1).args[0];
+				assert.include(evaluateCall1, 'mock-runner-node-module-1-js');
+				assert.include(evaluateCall1, 'window.__pa11y.runners["node-module-1"]');
+				assert.include(evaluateCall1, 'mock-runner-node-module-1-run');
+
+				const evaluateCall2 = puppeteer.mockPage.evaluate.getCall(2).args[0];
+				assert.include(evaluateCall2, 'mock-runner-node-module-2-js');
+				assert.include(evaluateCall2, 'window.__pa11y.runners["node-module-2"]');
+				assert.include(evaluateCall2, 'mock-runner-node-module-2-run');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -886,7 +887,7 @@ describe('lib/pa11y', function() {
 						'/mock-pa11y-runner/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-pa11y-runner'
+					run: /* istanbul ignore next */ () => 'mock-pa11y-runner-run'
 				};
 				// Quibble the prefixed module name
 				quibble('pa11y-runner-custom', mockRunnerModule);
@@ -903,11 +904,11 @@ describe('lib/pa11y', function() {
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
+				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(1).args[0],
-					/^\s*;\s*mock-pa11y-runner-js\s*;\s*;\s*window\.__pa11y\.runners\["custom"\] = \(\)\s*=>\s*'mock-pa11y-runner'\s*;\s*$/
-				);
+				assert.include(evaluateScript, 'mock-pa11y-runner-js');
+				assert.include(evaluateScript, 'window.__pa11y.runners["custom"]');
+				assert.include(evaluateScript, 'mock-pa11y-runner-run');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -926,14 +927,14 @@ describe('lib/pa11y', function() {
 				mockRunnerModule = {
 					supports: 'mock-support-string',
 					scripts: [
-						'/mock-full-module/vendor.js'
+						'/mock-full-module-runner/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-full-module'
+					run: /* istanbul ignore next */ () => 'mock-full-module-runner'
 				};
 				quibble('pa11y-runner-fullname', mockRunnerModule);
 
-				fs.readFileSync.withArgs('/mock-full-module/vendor.js').returns('mock-full-module-js');
+				fs.readFileSync.withArgs('/mock-full-module-runner/vendor.js').returns('mock-full-module-runner-js');
 
 				options.runners = ['pa11y-runner-fullname'];
 
@@ -945,11 +946,11 @@ describe('lib/pa11y', function() {
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
+				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(1).args[0],
-					/^\s*;\s*mock-full-module-js\s*;\s*;\s*window\.__pa11y\.runners\["pa11y-runner-fullname"\] = \(\)\s*=>\s*'mock-full-module'\s*;\s*$/
-				);
+				assert.include(evaluateScript, 'mock-full-module-runner-js');
+				assert.include(evaluateScript, 'window.__pa11y.runners["pa11y-runner-fullname"]');
+				assert.include(evaluateScript, 'mock-full-module-runner');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -972,14 +973,14 @@ describe('lib/pa11y', function() {
 				mockRunnerModule = {
 					supports: 'mock-support-string',
 					scripts: [
-						'/mock-relative-runner/vendor.js'
+						'/mock-relative-file-runner/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-relative-runner'
+					run: /* istanbul ignore next */ () => 'mock-relative-file-runner-run'
 				};
 				quibble(resolvedPath, mockRunnerModule);
 
-				fs.readFileSync.withArgs('/mock-relative-runner/vendor.js').returns('mock-relative-runner-js');
+				fs.readFileSync.withArgs('/mock-relative-file-runner/vendor.js').returns('mock-relative-file-runner-js');
 
 				options.runners = [relativePath];
 
@@ -991,15 +992,11 @@ describe('lib/pa11y', function() {
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
+				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
-				// Path separators are platform-specific (backslashes on Windows), so a dynamic
-				// RegExp is require. With that, must escape the file name to insert into the string,
-				// and the RegExp special characters to ensure they are treated as literals.
-				const escapedKey = JSON.stringify(relativePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(1).args[0],
-					new RegExp(`^\\s*;\\s*mock-relative-runner-js\\s*;\\s*;\\s*window\\.__pa11y\\.runners\\[${escapedKey}\\] = \\(\\)\\s*=>\\s*'mock-relative-runner'\\s*;\\s*$`)
-				);
+				assert.include(evaluateScript, 'mock-relative-file-runner-js');
+				assert.include(evaluateScript, `window.__pa11y.runners[${JSON.stringify(relativePath)}]`);
+				assert.include(evaluateScript, 'mock-relative-file-runner-run');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -1021,14 +1018,14 @@ describe('lib/pa11y', function() {
 				mockRunnerFileModule = {
 					supports: 'mock-support-string',
 					scripts: [
-						'/mock-runner-file-module/vendor.js'
+						'/mock-absolute-file-runner/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-runner-file-module'
+					run: /* istanbul ignore next */ () => 'mock-absolute-file-runner-run'
 				};
 				quibble(runnerFilePath, mockRunnerFileModule);
 
-				fs.readFileSync.withArgs('/mock-runner-file-module/vendor.js').returns('mock-runner-file-module-js');
+				fs.readFileSync.withArgs('/mock-absolute-file-runner/vendor.js').returns('mock-absolute-file-runner-js');
 
 				options.runners = [
 					runnerFilePath
@@ -1042,15 +1039,11 @@ describe('lib/pa11y', function() {
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
+				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
-				// Path separators are platform-specific (backslashes on Windows), so a dynamic
-				// RegExp is require. With that, must escape the file name to insert into the string,
-				// and the RegExp special characters to ensure they are treated as literals.
-				const escapedKey = JSON.stringify(runnerFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-				assert.match(
-					puppeteer.mockPage.evaluate.getCall(1).args[0],
-					new RegExp(`^\\s*;\\s*mock-runner-file-module-js\\s*;\\s*;\\s*window\\.__pa11y\\.runners\\[${escapedKey}\\] = \\(\\)\\s*=>\\s*'mock-runner-file-module'\\s*;\\s*$`)
-				);
+				assert.include(evaluateScript, 'mock-absolute-file-runner-js');
+				assert.include(evaluateScript, `window.__pa11y.runners[${JSON.stringify(runnerFilePath)}]`);
+				assert.include(evaluateScript, 'mock-absolute-file-runner-run');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -808,22 +808,25 @@ describe('lib/pa11y', function() {
 				await pa11y(options);
 			});
 
-			it('loads all runner scripts', function() {
-				assert.calledThrice(fs.readFileSync);
+			it('loads all the runner scripts from the `script` paths', function() {
+				assert.calledWith(fs.readFileSync, '/mock-runner-node-module-1/vendor.js');
+				assert.calledWith(fs.readFileSync, '/mock-runner-node-module-2/vendor.js');
 			});
 
 			it('evaluates all vendor script and runner JavaScript', function() {
 				assert.called(puppeteer.mockPage.evaluate);
 
 				const evaluateCall1 = puppeteer.mockPage.evaluate.getCall(1).args[0];
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateCall1, 'mock-runner-node-module-1-js');
 				assert.include(evaluateCall1, 'window.__pa11y.runners["node-module-1"]');
-				assert.include(evaluateCall1, 'mock-runner-node-module-1-run');
+				assert.include(evaluateCall1, '() => \'mock-runner-node-module-1-run\'');
 
 				const evaluateCall2 = puppeteer.mockPage.evaluate.getCall(2).args[0];
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateCall2, 'mock-runner-node-module-2-js');
 				assert.include(evaluateCall2, 'window.__pa11y.runners["node-module-2"]');
-				assert.include(evaluateCall2, 'mock-runner-node-module-2-run');
+				assert.include(evaluateCall2, '() => \'mock-runner-node-module-2-run\'');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -899,16 +902,17 @@ describe('lib/pa11y', function() {
 				await pa11y(options);
 			});
 
-			it('loads the runner from the pa11y-runner-<name> module', function() {
-				assert.calledTwice(fs.readFileSync);
+			it('loads the runner script from the `script` path', function() {
+				assert.calledWith(fs.readFileSync, '/mock-pa11y-runner/vendor.js');
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
 				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateScript, 'mock-pa11y-runner-js');
 				assert.include(evaluateScript, 'window.__pa11y.runners["custom"]');
-				assert.include(evaluateScript, 'mock-pa11y-runner-run');
+				assert.include(evaluateScript, '() => \'mock-pa11y-runner-run\'');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -930,27 +934,28 @@ describe('lib/pa11y', function() {
 						'/mock-full-module-runner/vendor.js'
 					],
 					// eslint-disable-next-line no-inline-comments
-					run: /* istanbul ignore next */ () => 'mock-full-module-runner'
+					run: /* istanbul ignore next */ () => 'mock-full-module-runner-run'
 				};
-				quibble('pa11y-runner-fullname', mockRunnerModule);
+				quibble('runner-fullname', mockRunnerModule);
 
 				fs.readFileSync.withArgs('/mock-full-module-runner/vendor.js').returns('mock-full-module-runner-js');
 
-				options.runners = ['pa11y-runner-fullname'];
+				options.runners = ['runner-fullname'];
 
 				await pa11y(options);
 			});
 
-			it('loads the runner from the full module name', function() {
-				assert.calledTwice(fs.readFileSync);
+			it('loads the runner script from the `script` path', function() {
+				assert.calledWith(fs.readFileSync, '/mock-full-module-runner/vendor.js');
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
 				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateScript, 'mock-full-module-runner-js');
-				assert.include(evaluateScript, 'window.__pa11y.runners["pa11y-runner-fullname"]');
-				assert.include(evaluateScript, 'mock-full-module-runner');
+				assert.include(evaluateScript, 'window.__pa11y.runners["runner-fullname"]');
+				assert.include(evaluateScript, '() => \'mock-full-module-runner-run\'');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -986,16 +991,17 @@ describe('lib/pa11y', function() {
 				await pa11y(options);
 			});
 
-			it('loads the runner from the relative path', function() {
-				assert.calledTwice(fs.readFileSync);
+			it('loads the runner script from the `script` path', function() {
+				assert.calledWith(fs.readFileSync, '/mock-relative-file-runner/vendor.js');
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
 				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateScript, 'mock-relative-file-runner-js');
 				assert.include(evaluateScript, `window.__pa11y.runners[${JSON.stringify(relativePath)}]`);
-				assert.include(evaluateScript, 'mock-relative-file-runner-run');
+				assert.include(evaluateScript, '() => \'mock-relative-file-runner-run\'');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -1033,16 +1039,17 @@ describe('lib/pa11y', function() {
 				await pa11y(options);
 			});
 
-			it('loads the runner script from the absolute file path', function() {
-				assert.calledTwice(fs.readFileSync);
+			it('loads the runner script from the `script` path', function() {
+				assert.calledWith(fs.readFileSync, '/mock-absolute-file-runner/vendor.js');
 			});
 
 			it('evaluates the vendor script and runner JavaScript', function() {
 				const evaluateScript = puppeteer.mockPage.evaluate.getCall(1).args[0];
 				assert.called(puppeteer.mockPage.evaluate);
+				// Includes runner script, registers runner, and includes runner run function
 				assert.include(evaluateScript, 'mock-absolute-file-runner-js');
 				assert.include(evaluateScript, `window.__pa11y.runners[${JSON.stringify(runnerFilePath)}]`);
-				assert.include(evaluateScript, 'mock-absolute-file-runner-run');
+				assert.include(evaluateScript, '() => \'mock-absolute-file-runner-run\'');
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -982,7 +982,7 @@ describe('lib/pa11y', function() {
 					// eslint-disable-next-line no-inline-comments
 					run: /* istanbul ignore next */ () => 'mock-relative-file-runner-run'
 				};
-				quibble(relativePath, mockRunnerModule);
+				quibble(path.join(process.cwd(), relativePath), mockRunnerModule);
 
 				fs.readFileSync.withArgs('/mock-relative-file-runner/vendor.js').returns('mock-relative-file-runner-js');
 

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -769,7 +769,7 @@ describe('lib/pa11y', function() {
 
 		});
 
-		describe('when `options.runners` is set', function() {
+		describe('when `options.runners` is set with multiple runners', function() {
 			let mockRunnerNodeModule1;
 			let mockRunnerNodeModule2;
 
@@ -815,8 +815,14 @@ describe('lib/pa11y', function() {
 			it('evaluates all vendor script and runner JavaScript', function() {
 				assert.called(puppeteer.mockPage.evaluate);
 
-				assert.match(puppeteer.mockPage.evaluate.getCall(1).args[0], /^\s*;\s*mock-runner-node-module-1-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-1"\] = \(\)\s*=>\s*'mock-runner-node-module-1'\s*;\s*$/);
-				assert.match(puppeteer.mockPage.evaluate.getCall(2).args[0], /^\s*;\s*mock-runner-node-module-2-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-2"\] = \(\)\s*=>\s*'mock-runner-node-module-2'\s*;\s*$/);
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(1).args[0],
+					/^\s*;\s*mock-runner-node-module-1-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-1"\] = \(\)\s*=>\s*'mock-runner-node-module-1'\s*;\s*$/
+				);
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(2).args[0],
+					/^\s*;\s*mock-runner-node-module-2-js\s*;\s*;\s*window\.__pa11y\.runners\["node-module-2"\] = \(\)\s*=>\s*'mock-runner-node-module-2'\s*;\s*$/
+				);
 			});
 
 			it('verifies that the runner supports the current version of Pa11y', function() {
@@ -865,6 +871,213 @@ describe('lib/pa11y', function() {
 				].join('\n'));
 			});
 
+		});
+
+		describe('when `options.runners` is set with a runner name (pa11y-runner-<name> format)', function() {
+			let mockRunnerModule;
+
+			beforeEach(async function() {
+				puppeteer.mockPage.evaluate.resetHistory();
+				fs.readFileSync.resetHistory();
+
+				mockRunnerModule = {
+					supports: 'mock-support-string',
+					scripts: [
+						'/mock-pa11y-runner/vendor.js'
+					],
+					// eslint-disable-next-line no-inline-comments
+					run: /* istanbul ignore next */ () => 'mock-pa11y-runner'
+				};
+				// Quibble the prefixed module name
+				quibble('pa11y-runner-custom', mockRunnerModule);
+
+				fs.readFileSync.withArgs('/mock-pa11y-runner/vendor.js').returns('mock-pa11y-runner-js');
+
+				options.runners = ['custom'];
+
+				await pa11y(options);
+			});
+
+			it('loads the runner from the pa11y-runner-<name> module', function() {
+				assert.calledTwice(fs.readFileSync);
+			});
+
+			it('evaluates the vendor script and runner JavaScript', function() {
+				assert.called(puppeteer.mockPage.evaluate);
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(1).args[0],
+					/^\s*;\s*mock-pa11y-runner-js\s*;\s*;\s*window\.__pa11y\.runners\["custom"\] = \(\)\s*=>\s*'mock-pa11y-runner'\s*;\s*$/
+				);
+			});
+
+			it('verifies that the runner supports the current version of Pa11y', function() {
+				assert.calledOnce(semver.satisfies);
+				assert.calledWithExactly(semver.satisfies, pkg.version, 'mock-support-string');
+			});
+		});
+
+		describe('when `options.runners` is set with a full module name', function() {
+			let mockRunnerModule;
+
+			beforeEach(async function() {
+				puppeteer.mockPage.evaluate.resetHistory();
+				fs.readFileSync.resetHistory();
+
+				mockRunnerModule = {
+					supports: 'mock-support-string',
+					scripts: [
+						'/mock-full-module/vendor.js'
+					],
+					// eslint-disable-next-line no-inline-comments
+					run: /* istanbul ignore next */ () => 'mock-full-module'
+				};
+				quibble('pa11y-runner-fullname', mockRunnerModule);
+
+				fs.readFileSync.withArgs('/mock-full-module/vendor.js').returns('mock-full-module-js');
+
+				options.runners = ['pa11y-runner-fullname'];
+
+				await pa11y(options);
+			});
+
+			it('loads the runner from the full module name', function() {
+				assert.calledTwice(fs.readFileSync);
+			});
+
+			it('evaluates the vendor script and runner JavaScript', function() {
+				assert.called(puppeteer.mockPage.evaluate);
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(1).args[0],
+					/^\s*;\s*mock-full-module-js\s*;\s*;\s*window\.__pa11y\.runners\["pa11y-runner-fullname"\] = \(\)\s*=>\s*'mock-full-module'\s*;\s*$/
+				);
+			});
+
+			it('verifies that the runner supports the current version of Pa11y', function() {
+				assert.calledOnce(semver.satisfies);
+				assert.calledWithExactly(semver.satisfies, pkg.version, 'mock-support-string');
+			});
+		});
+
+		describe('when `options.runners` is set with a relative path to cwd', function() {
+			let mockRunnerModule;
+			let relativePath;
+
+			beforeEach(async function() {
+				puppeteer.mockPage.evaluate.resetHistory();
+				fs.readFileSync.resetHistory();
+
+				relativePath = './custom-runner.js';
+				const resolvedPath = path.join(process.cwd(), relativePath);
+
+				mockRunnerModule = {
+					supports: 'mock-support-string',
+					scripts: [
+						'/mock-relative-runner/vendor.js'
+					],
+					// eslint-disable-next-line no-inline-comments
+					run: /* istanbul ignore next */ () => 'mock-relative-runner'
+				};
+				quibble(resolvedPath, mockRunnerModule);
+
+				fs.readFileSync.withArgs('/mock-relative-runner/vendor.js').returns('mock-relative-runner-js');
+
+				options.runners = [relativePath];
+
+				await pa11y(options);
+			});
+
+			it('loads the runner from the relative path', function() {
+				assert.calledTwice(fs.readFileSync);
+			});
+
+			it('evaluates the vendor script and runner JavaScript', function() {
+				assert.called(puppeteer.mockPage.evaluate);
+				// Path separators are platform-specific (backslashes on Windows), so a dynamic
+				// RegExp is require. With that, must escape the file name to insert into the string,
+				// and the RegExp special characters to ensure they are treated as literals.
+				const escapedKey = JSON.stringify(relativePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(1).args[0],
+					new RegExp(`^\\s*;\\s*mock-relative-runner-js\\s*;\\s*;\\s*window\\.__pa11y\\.runners\\[${escapedKey}\\] = \\(\\)\\s*=>\\s*'mock-relative-runner'\\s*;\\s*$`)
+				);
+			});
+
+			it('verifies that the runner supports the current version of Pa11y', function() {
+				assert.calledOnce(semver.satisfies);
+				assert.calledWithExactly(semver.satisfies, pkg.version, 'mock-support-string');
+			});
+		});
+
+		describe('when `options.runners` is set with an absolute path', function() {
+			let mockRunnerFileModule;
+			let runnerFilePath;
+
+			beforeEach(async function() {
+				puppeteer.mockPage.evaluate.resetHistory();
+				fs.readFileSync.resetHistory();
+
+				runnerFilePath = path.join(__dirname, '..', '..', '..', 'lib', 'runners', 'mock-runner.js');
+
+				mockRunnerFileModule = {
+					supports: 'mock-support-string',
+					scripts: [
+						'/mock-runner-file-module/vendor.js'
+					],
+					// eslint-disable-next-line no-inline-comments
+					run: /* istanbul ignore next */ () => 'mock-runner-file-module'
+				};
+				quibble(runnerFilePath, mockRunnerFileModule);
+
+				fs.readFileSync.withArgs('/mock-runner-file-module/vendor.js').returns('mock-runner-file-module-js');
+
+				options.runners = [
+					runnerFilePath
+				];
+
+				await pa11y(options);
+			});
+
+			it('loads the runner script from the absolute file path', function() {
+				assert.calledTwice(fs.readFileSync);
+			});
+
+			it('evaluates the vendor script and runner JavaScript', function() {
+				assert.called(puppeteer.mockPage.evaluate);
+				// Path separators are platform-specific (backslashes on Windows), so a dynamic
+				// RegExp is require. With that, must escape the file name to insert into the string,
+				// and the RegExp special characters to ensure they are treated as literals.
+				const escapedKey = JSON.stringify(runnerFilePath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+				assert.match(
+					puppeteer.mockPage.evaluate.getCall(1).args[0],
+					new RegExp(`^\\s*;\\s*mock-runner-file-module-js\\s*;\\s*;\\s*window\\.__pa11y\\.runners\\[${escapedKey}\\] = \\(\\)\\s*=>\\s*'mock-runner-file-module'\\s*;\\s*$`)
+				);
+			});
+
+			it('verifies that the runner supports the current version of Pa11y', function() {
+				assert.calledOnce(semver.satisfies);
+				assert.calledWithExactly(semver.satisfies, pkg.version, 'mock-support-string');
+			});
+		});
+
+		describe('when `options.runners` is set with a non-existent runner', function() {
+			let rejectedError;
+
+			beforeEach(async function() {
+				options.runners = [
+					'non-existent-runner-that-does-not-exist'
+				];
+
+				try {
+					await pa11y(options);
+				} catch (error) {
+					rejectedError = error;
+				}
+			});
+
+			it('rejects with a descriptive error', function() {
+				assert.instanceOf(rejectedError, Error);
+				assert.strictEqual(rejectedError.message, 'Runner "non-existent-runner-that-does-not-exist" could not be found');
+			});
 		});
 
 	});

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -967,8 +967,7 @@ describe('lib/pa11y', function() {
 				puppeteer.mockPage.evaluate.resetHistory();
 				fs.readFileSync.resetHistory();
 
-				relativePath = './custom-runner.js';
-				const resolvedPath = path.join(process.cwd(), relativePath);
+				relativePath = path.join('.', 'foo', 'custom-runner.js');
 
 				mockRunnerModule = {
 					supports: 'mock-support-string',
@@ -978,7 +977,7 @@ describe('lib/pa11y', function() {
 					// eslint-disable-next-line no-inline-comments
 					run: /* istanbul ignore next */ () => 'mock-relative-file-runner-run'
 				};
-				quibble(resolvedPath, mockRunnerModule);
+				quibble(relativePath, mockRunnerModule);
 
 				fs.readFileSync.withArgs('/mock-relative-file-runner/vendor.js').returns('mock-relative-file-runner-js');
 


### PR DESCRIPTION
This PR makes the following updates:

- [x] Fixes escaping of custom runner file names for Windows paths and other special characters, closes #796.
  - Using `JSON.stringify()` escapes any required characters (for example, a filename with a single quote is valid, but would also cause an error). This does return a double quoted string, so required a couple of updates to unit tests expecting a single quoted name.
- [x] Updates runner loading to follow the same methodology as [loading reporters](https://github.com/pa11y/pa11y/blob/main/bin/pa11y.js#L205-L234), fixing #797. This also replaces #530.
  -  Extract `requireFirst` to `helpers` module for reusability.
  - Fix issues with loading reporter modules `pa11y-runner-<runner>` with `--runner <runner>`
  - Fix loading via relative path to be relative to cwd
- [x] Updates runner unit tests to cover the all nominal cases (`pa11y-runner-<name>` module, `<runner name>` module, file path relative to `cwd()`, absolute file path) as well as loading failure.
- [x] Adds integration tests for custom runners.
- [x] Update `runner` section of README for clarity and consistency with these updates (also the `reporter` section for consistency)