### PR TITLE
Release pa11y@9.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 9.1.1 (2026-02-26)
+
+* Fix several issues with loading custom runners, including errors when loading any custom runner on Windows. (#798)
+* Update `debug` messages related to opening the page and navigating to the target URL. (#701)
+* Update dependencies (no functional changes)
+
+### Full diff for `pa11y@9.1.1`
+
+* [9.1.0...9.1.1](https://github.com/pa11y/pa11y/compare/9.1.0...9.1.1)
+
 ## 9.1.0 (2026-02-03)
 
 Pa11y 9.1 includes updates and improvements to both `htmlcs` and `axe` runners, replacement of `mockery` with `quibble` in the test suite to resolve security issues, an upgrade to ESLint v9 with flat config, and various other updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y",
-      "version": "9.1.0",
+      "version": "9.1.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@pa11y/html_codesniffer": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "a11y",


### PR DESCRIPTION
Changes in this PR:

* [x] Updated `CHANGELOG.md`
* [x] Updated `package.json`/`package-lock.json` to version 9.1.1
* [x] Created [draft release for v9.1.1](https://github.com/pa11y/pa11y/releases).

