### PR TITLE
test: add unit tests for lib/helpers.js requireFirst

### DIFF
--- a/test/unit/lib/fixtures/helpers-throwing-module.js
+++ b/test/unit/lib/fixtures/helpers-throwing-module.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// This file exists to be `require`d by test/unit/lib/helpers.test.js.
+// It throws an error that is not a `MODULE_NOT_FOUND` error, to test
+// that `requireFirst` rethrows errors it cannot recover from.
+throw new Error('mock module load error');

--- a/test/unit/lib/helpers.test.js
+++ b/test/unit/lib/helpers.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('proclaim');
+const path = require('path');
+const quibble = require('quibble');
+
+describe('lib/helpers', function() {
+	let helpers;
+	let requireFirst;
+
+	beforeEach(function() {
+		helpers = require('../../../lib/helpers');
+		({requireFirst} = helpers);
+	});
+
+	it('is an object', function() {
+		assert.isObject(helpers);
+	});
+
+	describe('.requireFirst(stack, defaultReturn)', function() {
+
+		it('is a function', function() {
+			assert.isFunction(requireFirst);
+		});
+
+		describe('when `stack` is empty', function() {
+
+			it('returns `defaultReturn`', function() {
+				const defaultReturn = {mockDefault: true};
+				assert.strictEqual(requireFirst([], defaultReturn), defaultReturn);
+			});
+
+		});
+
+		describe('when the first path in `stack` can be required', function() {
+			let mockModule;
+			let result;
+
+			beforeEach(function() {
+				mockModule = {mockModule: true};
+				quibble('mock-first-module', mockModule);
+				result = requireFirst(['mock-first-module'], {mockDefault: true});
+			});
+
+			it('returns the required module', function() {
+				assert.strictEqual(result, mockModule);
+			});
+
+		});
+
+		describe('when earlier paths in `stack` cannot be found', function() {
+			let mockModule;
+			let stack;
+			let result;
+
+			beforeEach(function() {
+				mockModule = {mockModule: true};
+				quibble('mock-second-module', mockModule);
+				stack = [
+					'mock-module-that-does-not-exist',
+					'mock-second-module'
+				];
+				result = requireFirst(stack, {mockDefault: true});
+			});
+
+			it('skips them and returns the first module that can be required', function() {
+				assert.strictEqual(result, mockModule);
+			});
+
+			it('removes the skipped paths from `stack` as it goes', function() {
+				assert.deepEqual(stack, []);
+			});
+
+		});
+
+		describe('when no path in `stack` can be found', function() {
+
+			it('returns `defaultReturn`', function() {
+				const defaultReturn = {mockDefault: true};
+				const stack = [
+					'mock-module-that-does-not-exist',
+					'another-mock-module-that-does-not-exist'
+				];
+				assert.strictEqual(requireFirst(stack, defaultReturn), defaultReturn);
+			});
+
+		});
+
+		describe('when the first path in `stack` throws an error other than `MODULE_NOT_FOUND`', function() {
+			const throwingModulePath = path.join(__dirname, 'fixtures', 'helpers-throwing-module.js');
+			let caughtError;
+
+			beforeEach(function() {
+				caughtError = undefined;
+				try {
+					requireFirst([throwingModulePath, 'mock-module-that-does-not-exist'], {});
+				} catch (error) {
+					caughtError = error;
+				}
+			});
+
+			it('rethrows the error rather than trying the next path in `stack`', function() {
+				assert.instanceOf(caughtError, Error);
+				assert.strictEqual(caughtError.message, 'mock module load error');
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
## What

Adds a unit test file for `lib/helpers.js`, which previously had none, plus a small fixture module used to exercise one of its error paths.

## Why

`requireFirst(stack, defaultReturn)` in `lib/helpers.js` is used by both `bin/pa11y.js` and `lib/pa11y.js` to load config files and runner modules from a list of candidate paths. It had no dedicated test file. Coverage on the file sat at 92% statements / 83.33% branches, missing exactly the branch where a required path exists but throws something other than `MODULE_NOT_FOUND` (line 19, the `throw error` rethrow).

## What changed

- `test/unit/lib/helpers.test.js` — covers:
  - empty `stack` returns `defaultReturn`
  - a resolvable path in `stack` is required and returned
  - unresolvable paths earlier in `stack` are skipped in order until a resolvable one is found
  - an exhausted `stack` (nothing resolvable) returns `defaultReturn`
  - a non-`MODULE_NOT_FOUND` error thrown by `require()` is rethrown rather than swallowed
- `test/unit/lib/fixtures/helpers-throwing-module.js` — a tiny fixture module that throws a plain `Error` on require, used only by the last test above to exercise the rethrow branch.

Followed the repo's existing conventions: `proclaim` assertions, `quibble` to stub `require()` targets for the "found"/"not found" cases (matching how `test/unit/lib/pa11y.test.js` already quibbles bare module names like `'node-module-1'` for its runner-loading tests), tabs for indentation.

## How to verify

```
npm install
npm run lint
npm run test-coverage
npm run verify-coverage
```

## Checks run

- `npm run lint` — clean (only the pre-existing, unrelated `no-shadow` warning in `lib/pa11y.js:426` remains)
- `npm run test-coverage` — 397 passing (was 389), 0 failing
- `npm run verify-coverage` — passes; `lib/helpers.js` goes from 92%/83.33% (lines/branches) to 100%/100%
- Fork CI (lint + test matrix across ubuntu/macos/windows, node 22/24/26) — all green: https://github.com/olitreadwell/pa11y/actions/runs/30909490139

## Confidence

High. This is additive test-only code — no production code paths changed — verified locally with the repo's own test/lint scripts before pushing, and cross-checked `requireFirst`'s implementation in `lib/helpers.js` line by line against each test case.

## CLA / DCO

Not required — no CLA bot or DCO check found on `pa11y/pa11y` (no `.github/workflows` signature/CLA checks, no `PULL_REQUEST_TEMPLATE.md`, no branch-protection signed-commit requirement detected via the API).