### PR TITLE
Resolving the Symlink Vulnerability of extract-zip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "envinfo": "~7.21.0",
         "mustache": "~4.2.0",
         "node.extend": "~2.0.3",
-        "puppeteer": "^25.8.0",
+        "puppeteer": "^25.9.0",
         "semver": "~7.8.0"
       },
       "bin": {
@@ -2434,9 +2434,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
-      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.9.0.tgz",
+      "integrity": "sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2444,7 +2444,7 @@
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.8.0",
+        "puppeteer-core": "25.9.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
-      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
+      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "3.2.1",
@@ -2465,7 +2465,7 @@
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "envinfo": "~7.21.0",
     "mustache": "~4.2.0",
     "node.extend": "~2.0.3",
-    "puppeteer": "^25.8.0",
+    "puppeteer": "^25.9.0",
     "semver": "~7.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading from Puppeteer 25.8.0 to 25.9.0 fixes the security issue:
 `extract-zip unvalidated symlink path traversal`
The @puppeteer/browsers Upgrade: The Puppeteer ecosystem officially removed the old, frozen extract-zip module from its internal tooling