### PR TITLE
Restore the whole-run timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ pa11y(url, {
 });
 ```
 
-Defaults to `30000`.
+Defaults to `60000`.
 
 ### `userAgent` (string)
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -50,10 +50,11 @@ async function pa11y(url, options = {}, callback) {
 	try {
 		option.verifyOptions(options, pa11y.allowedStandards);
 
-		// Call the Pa11y test runner, applying a timeout.
-		pa11yResults = await runPa11yTest(url, options, state, {
-			signal: AbortSignal.timeout(options.timeout)
-		});
+		// Call the Pa11y test runner, applying a timeout to the whole run.
+		pa11yResults = await Promise.race([
+			runPa11yTest(url, options, state),
+			rejectOnTimeout(options.timeout)
+		]);
 	} catch (error) {
 		if (callback) {
 			pa11yError = error;
@@ -65,6 +66,23 @@ async function pa11y(url, options = {}, callback) {
 	}
 
 	return callback ? callback(pa11yError, pa11yResults) : pa11yResults;
+}
+
+/**
+ * Build a promise which never resolves, and rejects once the given time elapses.
+ * @private
+ * @param {Number} timeout - The time in milliseconds to wait before rejecting.
+ * @returns {Promise<never>} A promise which rejects with a timeout error.
+ */
+function rejectOnTimeout(timeout) {
+	const signal = AbortSignal.timeout(timeout);
+	return new Promise((resolve, reject) => {
+		signal.addEventListener('abort', () => {
+			const error = new Error(`Pa11y timed out (${timeout}ms)`);
+			error.name = 'TimeoutError';
+			reject(error);
+		}, {once: true});
+	});
 }
 
 /**

--- a/test/integration/cli/timeout.test.js
+++ b/test/integration/cli/timeout.test.js
@@ -22,8 +22,8 @@ describe('CLI timeout', function() {
 
 		it('outputs a timeout error', function() {
 			assert.match(pa11yResponse.output, /timeouterror/i);
-			assert.match(pa11yResponse.output, /navigation timeout/i);
-			assert.match(pa11yResponse.output, /100 ms/i);
+			assert.match(pa11yResponse.output, /pa11y timed out/i);
+			assert.match(pa11yResponse.output, /100ms/i);
 		});
 
 	});

--- a/test/unit/lib/pa11y.test.js
+++ b/test/unit/lib/pa11y.test.js
@@ -232,6 +232,35 @@ describe('lib/pa11y', function() {
 
 		});
 
+		describe('when the test run takes longer than `options.timeout`', function() {
+			let rejectedError;
+
+			beforeEach(async function() {
+				// Navigation succeeds, so the only thing that can end this run
+				// is the whole-run timeout.
+				puppeteer.mockBrowser.close.resetHistory();
+				puppeteer.mockPage.evaluate.returns(new Promise(() => {
+					// Never settles.
+				}));
+				try {
+					await pa11y('https://mock-url/', {timeout: 20});
+				} catch (error) {
+					rejectedError = error;
+				}
+			});
+
+			it('rejects with a timeout error naming the timeout', function() {
+				assert.instanceOf(rejectedError, Error);
+				assert.strictEqual(rejectedError.name, 'TimeoutError');
+				assert.strictEqual(rejectedError.message, 'Pa11y timed out (20ms)');
+			});
+
+			it('closes the browser', function() {
+				assert.calledOnce(puppeteer.mockBrowser.close);
+			});
+
+		});
+
 		describe('when Headless Chrome errors', function() {
 			let headlessChromeError;
 			let rejectedError;


### PR DESCRIPTION
`lib/pa11y.js:54` calls `runPa11yTest(url, options, state, {signal: AbortSignal.timeout(options.timeout)})`, but `runPa11yTest` is declared with three parameters at `lib/pa11y.js:79`. The fourth argument is discarded, and `signal` appears exactly once in `lib/` and `bin/` — nothing listens to it. So since #694 (v8.0.0) the only surviving use of `options.timeout` has been `page.goto` at `lib/pa11y.js:266-269`; browser launch, actions, runner injection, `wait` and the in-page evaluate are all unbounded.

Measured here, same command before and after, on a local file with an `img` missing `alt`:

```
$ time node ./bin/pa11y.js file://…/page.html --timeout 5000 --wait 30000 --reporter cli
before:  1 Errors                            31.6s
after:   Error: Pa11y timed out (5000ms)      5.2s
control (drop --wait, same --timeout 5000):  1 Errors   1.4s
```

`README.md:630`: "Please note that this is the timeout for the _entire_ test run (including time to initialise Chrome, load the page, and run the tests)." The pre-#694 code did that via `p-timeout` and rejected with `Pa11y timed out (${options.timeout}ms)`.

Why no test caught it: the same commit deleted the unit test asserting the timeout call, and rewrote `test/integration/cli/timeout.test.js` from `/pa11y timed out/i` + `/100ms/i` to `/navigation timeout/i` + `/100 ms/i` — the expected values were taken from the new output.

This races the run against the timeout again and rejects with a `TimeoutError`, restoring the two integration assertions to their pre-#694 values. Also `README.md:638` said the default was `30000`; `pa11y.defaults.timeout` has been `60000` since 6.1.0.

**Blast radius:** any run that currently finishes after `options.timeout` will now fail instead. That is the documented and pre-v8 behaviour, but a real change for anyone relying on the last two years of unbounded runs. Happy to gate it differently if you'd rather not change that in a patch release.

`npm test`: 389 unit + 96 integration on clean `main`, 391 unit + 96 integration here; coverage 99.31/98.31/100/99.31 against the 90/90/90 gate. `npm run lint` reports the same single pre-existing `no-shadow` warning before and after.

Mutants, to show the tests discriminate: reverting `lib/pa11y.js` alone makes the new unit block's hook time out (`pa11y()` never settles) and drops integration to 95/96; keeping the race but dropping `error.name = 'TimeoutError'` fails on `'Error' === 'TimeoutError'` and on the untouched `/timeouterror/i` assertion; putting the race around only `runPa11yWithOptions` instead still leaves integration reporting `TimeoutError: Navigation timeout of 100 ms`.

Not tested: Windows, `--config` precedence, and the `ignoreUrl: true` path with a caller-supplied `browser`/`page` — that path skips `gotoUrl` entirely, so it had no timeout at all before this, and I did not add a test for it.

This change was prepared with AI assistance (Claude Opus 5).
